### PR TITLE
improvement(*_display_rcs): y-axis vol depol

### DIFF
--- a/config/pollyConfigs/polly_global_config.json
+++ b/config/pollyConfigs/polly_global_config.json
@@ -184,6 +184,7 @@
     "yLim_WVConst": [0, 20],
     "yLim_FR_RCS": [0, 20000],
     "yLim_NR_RCS": [0, 3000],
+    "yLim_FR_DR": [0, 15000],
     "yLim_att_beta": [0, 15000],
     "yLim_Quasi_Params": [0, 12000],
     "yLim_WV_RH": [0, 7000],

--- a/lib/polly_1v2_func_lib/polly_1v2_display_rcs.m
+++ b/lib/polly_1v2_func_lib/polly_1v2_display_rcs.m
@@ -27,10 +27,9 @@ RCS_FR_532 = squeeze(data.signal(flagChannel532, :, :)) ./ repmat(data.mShots(fl
 RCS_NR_532 = squeeze(data.signal(flagChannel532NR, :, :)) ./ repmat(data.mShots(flagChannel532NR, :), numel(data.height), 1) * 150 / double(data.hRes) .* repmat(transpose(data.height), 1, numel(data.mTime)).^2;
 
 volDepol_532 = data.volDepol_532;
-volDepol_532(:, (data.depCalMask ~= 0) | (data.fogMask)) = NaN;
-
-yLim_FR = config.yLim_FR_RCS;
-yLim_NR = config.yLim_NR_RCS;
+yLim_FR_RCS = config.yLim_FR_RCS;
+yLim_NR_RCS = config.yLim_NR_RCS;
+yLim_FR_DR = config.yLim_FR_DR;
 RCS532FRColorRange = config.zLim_FR_RCS_532;
 RCS532NRColorRange = config.zLim_NR_RCS_532;
 
@@ -54,12 +53,12 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis(zLim_FR_RCS_532);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_FR);
+    ylim(yLim_FR_RCS);
     xlabel('UTC');
     ylabel('Height (m)');
     title(sprintf('Range-Corrected Signal at %snm %s for %s at %s', '532', 'Far-Range', campaignInfo.name, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none');
     set(gca, 'Box', 'on', 'TickDir', 'out');
-    set(gca, 'ytick', linspace(yLim_FR(1), yLim_FR(2), 6), 'yminortick', 'on');
+    set(gca, 'ytick', linspace(yLim_FR_RCS(1), yLim_FR_RCS(2), 6), 'yminortick', 'on');
     [xtick, xtickstr] = timelabellayout(data.mTime, 'HH:MM');
     set(gca, 'xtick', xtick, 'xticklabel', xtickstr);
     text(-0.04, -0.13, sprintf('%s', datestr(data.mTime(1), 'yyyy-mm-dd')), 'Units', 'Normal');
@@ -87,12 +86,12 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis(zLim_NR_RCS_532);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_NR);
+    ylim(yLim_NR_RCS);
     xlabel('UTC');
     ylabel('Height (m)');
     title(sprintf('Range-Corrected Signal at %snm %s for %s at %s', '532', 'Near-Range', campaignInfo.name, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none');
     set(gca, 'Box', 'on', 'TickDir', 'out');
-    set(gca, 'ytick', linspace(yLim_NR(1), yLim_NR(2), 6), 'yminortick', 'on');
+    set(gca, 'ytick', linspace(yLim_NR_RCS(1), yLim_NR_RCS(2), 6), 'yminortick', 'on');
     [xtick, xtickstr] = timelabellayout(data.mTime, 'HH:MM');
     set(gca, 'xtick', xtick, 'xticklabel', xtickstr);
     text(-0.04, -0.13, sprintf('%s', datestr(data.mTime(1), 'yyyy-mm-dd')), 'Units', 'Normal');
@@ -119,12 +118,12 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis([0, 0.4]);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_FR);
+    ylim(yLim_FR_DR);
     xlabel('UTC');
     ylabel('Height (m)');
     title(sprintf('Volume Depolarization Ratio at %snm for %s at %s', '532', campaignInfo.name, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none');
     set(gca, 'Box', 'on', 'TickDir', 'out');
-    set(gca, 'ytick', linspace(yLim_FR(1), yLim_FR(2), 6), 'yminortick', 'on');
+    set(gca, 'ytick', linspace(yLim_FR_DR(1), yLim_FR_DR(2), 6), 'yminortick', 'on');
     [xtick, xtickstr] = timelabellayout(data.mTime, 'HH:MM');
     set(gca, 'xtick', xtick, 'xticklabel', xtickstr);
     text(-0.04, -0.13, sprintf('%s', datestr(data.mTime(1), 'yyyy-mm-dd')), 'Units', 'Normal');
@@ -157,7 +156,7 @@ elseif strcmpi(processInfo.visualizationMode, 'python')
 
     %% display rcs 
     tmpFile = fullfile(tmpFolder, [basename(tempname), '.mat']);
-    save(tmpFile, 'figDPI', 'mTime', 'height', 'depCalMask', 'fogMask', 'yLim_FR', 'yLim_NR', 'RCS_FR_532', 'RCS_NR_532', 'volDepol_532', 'processInfo', 'campaignInfo', 'taskInfo', 'xtick', 'xtickstr', 'RCS532FRColorRange', 'RCS532NRColorRange', '-v6');
+    save(tmpFile, 'figDPI', 'mTime', 'height', 'depCalMask', 'fogMask', 'yLim_FR_RCS', 'yLim_NR_RCS', 'yLim_FR_DR', 'RCS_FR_532', 'RCS_NR_532', 'volDepol_532', 'processInfo', 'campaignInfo', 'taskInfo', 'xtick', 'xtickstr', 'RCS532FRColorRange', 'RCS532NRColorRange', '-v6');
     flag = system(sprintf('%s %s %s %s', fullfile(processInfo.pyBinDir, 'python'), fullfile(pyFolder, 'polly_1v2_display_rcs.py'), tmpFile, saveFolder));
     if flag ~= 0
         warning('Error in executing %s', 'polly_1v2_display_rcs.py');

--- a/lib/polly_1v2_func_lib/polly_1v2_display_rcs.py
+++ b/lib/polly_1v2_func_lib/polly_1v2_display_rcs.py
@@ -117,8 +117,9 @@ def polly_1v2_display_rcs(tmpFile, saveFolder):
         dataFilename = mat['taskInfo']['dataFilename'][0][0][0]
         xtick = mat['xtick'][0][:]
         xticklabel = mat['xtickstr']
-        yLim_FR = mat['yLim_FR'][:][0]
-        yLim_NR = mat['yLim_NR'][:][0]
+        yLim_FR_RCS = mat['yLim_FR_RCS'][:][0]
+        yLim_NR_RCS = mat['yLim_NR_RCS'][:][0]
+        yLim_FR_DR = mat['yLim_FR_DR'][:][0]
         RCS532FRColorRange = mat['RCS532FRColorRange'][:][0]
         RCS532NRColorRange = mat['RCS532NRColorRange'][:][0]
     except Exception as e:
@@ -155,7 +156,7 @@ def polly_1v2_display_rcs(tmpFile, saveFolder):
 
     ax.yaxis.set_major_locator(MultipleLocator(2500))
     ax.yaxis.set_minor_locator(MultipleLocator(500))
-    ax.set_ylim([yLim_FR[0], yLim_FR[1]])
+    ax.set_ylim([yLim_FR_RCS[0], yLim_FR_RCS[1]])
     ax.set_xticks(xtick.tolist())
     ax.set_xticklabels(celltolist(xticklabel))
     ax.tick_params(axis='both', which='major', labelsize=15,
@@ -202,7 +203,7 @@ def polly_1v2_display_rcs(tmpFile, saveFolder):
 
     ax.yaxis.set_major_locator(MultipleLocator(1000))
     ax.yaxis.set_minor_locator(MultipleLocator(200))
-    ax.set_ylim([yLim_NR[0], yLim_NR[1]])
+    ax.set_ylim([yLim_NR_RCS[0], yLim_NR_RCS[1]])
     ax.set_xticks(xtick.tolist())
     ax.set_xticklabels(celltolist(xticklabel))
     ax.tick_params(axis='both', which='major', labelsize=15,
@@ -248,7 +249,7 @@ def polly_1v2_display_rcs(tmpFile, saveFolder):
 
     ax.yaxis.set_major_locator(MultipleLocator(2500))
     ax.yaxis.set_minor_locator(MultipleLocator(500))
-    ax.set_ylim([yLim_FR[0], yLim_FR[1]])
+    ax.set_ylim([yLim_FR_DR[0], yLim_FR_DR[1]])
     ax.set_xticks(xtick.tolist())
     ax.set_xticklabels(celltolist(xticklabel))
     ax.tick_params(axis='both', which='major', labelsize=15,

--- a/lib/polly_general_func_lib/pollyxt_display_rcs.m
+++ b/lib/polly_general_func_lib/pollyxt_display_rcs.m
@@ -14,6 +14,23 @@ function pollyxt_display_rcs(data, taskInfo, config)
 
 global defaults processInfo campaignInfo
 
+flagChannel355 = config.isFR & config.is355nm & config.isTot;
+flagChannel532 = config.isFR & config.is532nm & config.isTot;
+flagChannel1064 = config.isFR & config.is1064nm & config.isTot;
+flagChannel532NR = config.isNR & config.is532nm & config.isTot;
+flagChannel355NR = config.isNR & config.is355nm & config.isTot;
+
+yLim_FR_RCS = config.yLim_FR_RCS;
+yLim_NR_RCS = config.yLim_NR_RCS;
+yLim_FR_DR = config.yLim_FR_DR;
+volDepol_355 = data.volDepol_355;
+volDepol_532 = data.volDepol_532;
+RCS355FRColorRange = config.zLim_FR_RCS_355;
+RCS532FRColorRange = config.zLim_FR_RCS_532;
+RCS1064FRColorRange = config.zLim_FR_RCS_1064;
+RCS355NRColorRange = config.zLim_NR_RCS_355;
+RCS532NRColorRange = config.zLim_NR_RCS_355;
+
 if strcmpi(processInfo.visualizationMode, 'matlab')
     %% parameter initialize
     fileRCS355FR = fullfile(processInfo.pic_folder, campaignInfo.name, datestr(data.mTime(1), 'yyyy'), datestr(data.mTime(1), 'mm'), datestr(data.mTime(1), 'dd'), sprintf('%s_RCS_FR_355.png', rmext(taskInfo.dataFilename)));
@@ -23,19 +40,6 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     fileRCS532NR = fullfile(processInfo.pic_folder, campaignInfo.name, datestr(data.mTime(1), 'yyyy'), datestr(data.mTime(1), 'mm'), datestr(data.mTime(1), 'dd'), sprintf('%s_RCS_NR_532.png', rmext(taskInfo.dataFilename)));
     fileVolDepol355 = fullfile(processInfo.pic_folder, campaignInfo.name, datestr(data.mTime(1), 'yyyy'), datestr(data.mTime(1), 'mm'), datestr(data.mTime(1), 'dd'), sprintf('%s_VDR_355.png', rmext(taskInfo.dataFilename)));
     fileVolDepol532 = fullfile(processInfo.pic_folder, campaignInfo.name, datestr(data.mTime(1), 'yyyy'), datestr(data.mTime(1), 'mm'), datestr(data.mTime(1), 'dd'), sprintf('%s_VDR_532.png', rmext(taskInfo.dataFilename)));
-    flagChannel355 = config.isFR & config.is355nm & config.isTot;
-    flagChannel532 = config.isFR & config.is532nm & config.isTot;
-    flagChannel1064 = config.isFR & config.is1064nm & config.isTot;
-    flagChannel532NR = config.isNR & config.is532nm & config.isTot;
-    flagChannel355NR = config.isNR & config.is355nm & config.isTot;
-
-    yLim_FR = config.yLim_FR_RCS;
-    yLim_NR = config.yLim_NR_RCS;
-    RCS355FRColorRange = config.zLim_FR_RCS_355;
-    RCS532FRColorRange = config.zLim_FR_RCS_532;
-    RCS1064FRColorRange = config.zLim_FR_RCS_1064;
-    RCS355NRColorRange = config.zLim_NR_RCS_355;
-    RCS532NRColorRange = config.zLim_NR_RCS_532;
 
     %% visualization
     load('myjet_colormap.mat')   % load colormap
@@ -52,12 +56,12 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis(RCS355FRColorRange);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_RCS_FR);
+    ylim(yLim_FR_RCS);
     xlabel('UTC', 'FontSize', 7);
     ylabel('Height (m)', 'FontSize', 7);
     title(sprintf('Range-Corrected Signal at %snm Far-Range from %s at %s', '355', taskInfo.pollyVersion, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none', 'FontSize', 7);
     set(gca, 'Box', 'on', 'TickDir', 'out');
-    set(gca, 'ytick', linspace(yLim_RCS_FR(1), yLim_RCS_FR(2), 7), 'yminortick', 'on', 'FontSize', 7);
+    set(gca, 'ytick', linspace(yLim_FR_RCS(1), yLim_FR_RCS(2), 7), 'yminortick', 'on', 'FontSize', 7);
     set(gca, 'xtick', xtick, 'xticklabel', xtickstr);
     text(-0.04, -0.13, sprintf('%s', datestr(data.mTime(1), 'yyyy-mm-dd')), 'Units', 'Normal', 'FontSize', 7);
     text(0.90, -0.13, sprintf('Version %s', processInfo.programVersion), 'Units', 'Normal', 'FontSize', 7);
@@ -85,12 +89,12 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis(RCS532FRColorRange);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_RCS_FR);
+    ylim(yLim_FR_RCS);
     xlabel('UTC', 'FontSize', 7);
     ylabel('Height (m)', 'FontSize', 7);
     title(sprintf('Range-Corrected Signal at %snm Far-Range from %s at %s', '532', taskInfo.pollyVersion, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none', 'FontSize', 7);
     set(gca, 'Box', 'on', 'TickDir', 'out');
-    set(gca, 'ytick', linspace(yLim_RCS_FR(1), yLim_RCS_FR(2), 7), 'yminortick', 'on', 'FontSize', 7);
+    set(gca, 'ytick', linspace(yLim_FR_RCS(1), yLim_FR_RCS(2), 7), 'yminortick', 'on', 'FontSize', 7);
     set(gca, 'xtick', xtick, 'xticklabel', xtickstr);
     text(-0.04, -0.13, sprintf('%s', datestr(data.mTime(1), 'yyyy-mm-dd')), 'Units', 'Normal', 'FontSize', 7);
     text(0.90, -0.13, sprintf('Version %s', processInfo.programVersion), 'Units', 'Normal', 'FontSize', 7);
@@ -118,12 +122,12 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis(RCS1064FRColorRange);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_RCS_FR);
+    ylim(yLim_FR_RCS);
     xlabel('UTC', 'FontSize', 7);
     ylabel('Height (m)', 'FontSize', 7);
     title(sprintf('Range-Corrected Signal at %snm Far-Range from %s at %s', '1064', taskInfo.pollyVersion, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none', 'FontSize', 7);
     set(gca, 'Box', 'on', 'TickDir', 'out');
-    set(gca, 'ytick', linspace(yLim_RCS_FR(1), yLim_RCS_FR(2), 7), 'yminortick', 'on', 'FontSize', 7);
+    set(gca, 'ytick', linspace(yLim_FR_RCS(1), yLim_FR_RCS(2), 7), 'yminortick', 'on', 'FontSize', 7);
     set(gca, 'xtick', xtick, 'xticklabel', xtickstr);
     text(-0.04, -0.13, sprintf('%s', datestr(data.mTime(1), 'yyyy-mm-dd')), 'Units', 'Normal', 'FontSize', 7);
     text(0.90, -0.13, sprintf('Version %s', processInfo.programVersion), 'Units', 'Normal', 'FontSize', 7);
@@ -151,12 +155,12 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis(RCS355NRColorRange);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_RCS_NR);
+    ylim(yLim_NR_RCS);
     xlabel('UTC', 'FontSize', 7);
     ylabel('Height (m)', 'FontSize', 7);
     title(sprintf('Range-Corrected Signal at %snm Near-Range from %s at %s', '355', taskInfo.pollyVersion, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none', 'FontSize', 7);
     set(gca, 'Box', 'on', 'TickDir', 'out');
-    set(gca, 'ytick', yLim_RCS_NR(1):1000:yLim_RCS_NR(2), 'yminortick', 'on', 'FontSize', 7);
+    set(gca, 'ytick', yLim_NR_RCS(1):1000:yLim_NR_RCS(2), 'yminortick', 'on', 'FontSize', 7);
     set(gca, 'xtick', xtick, 'xticklabel', xtickstr);
     text(-0.04, -0.13, sprintf('%s', datestr(data.mTime(1), 'yyyy-mm-dd')), 'Units', 'Normal', 'FontSize', 7);
     text(0.90, -0.13, sprintf('Version %s', processInfo.programVersion), 'Units', 'Normal', 'FontSize', 7);
@@ -184,12 +188,12 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis(RCS532NRColorRange);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_RCS_NR);
+    ylim(yLim_NR_RCS);
     xlabel('UTC', 'FontSize', 7);
     ylabel('Height (m)', 'FontSize', 7);
     title(sprintf('Range-Corrected Signal at %snm Near-Range from %s at %s', '532', taskInfo.pollyVersion, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none', 'FontSize', 7);
     set(gca, 'Box', 'on', 'TickDir', 'out');
-    set(gca, 'ytick', yLim_RCS_NR(1):1000:yLim_RCS_NR(2), 'yminortick', 'on', 'FontSize', 7);
+    set(gca, 'ytick', yLim_NR_RCS(1):1000:yLim_NR_RCS(2), 'yminortick', 'on', 'FontSize', 7);
     set(gca, 'xtick', xtick, 'xticklabel', xtickstr);
     text(-0.04, -0.13, sprintf('%s', datestr(data.mTime(1), 'yyyy-mm-dd')), 'Units', 'Normal', 'FontSize', 7);
     text(0.90, -0.13, sprintf('Version %s', processInfo.programVersion), 'Units', 'Normal', 'FontSize', 7);
@@ -217,12 +221,12 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis([0, 0.4]);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_RCS_FR);
+    ylim(yLim_FR_RCS);
     xlabel('UTC', 'FontSize', 7);
     ylabel('Height (m)', 'FontSize', 7);
     title(sprintf('Volume Depolarization Ratio at %snm from %s at %s', '532', taskInfo.pollyVersion, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none', 'FontSize', 7);
     set(gca, 'Box', 'on', 'TickDir', 'out');
-    set(gca, 'ytick', linspace(yLim_RCS_FR(1), yLim_RCS_FR(2), 7), 'yminortick', 'on');
+    set(gca, 'ytick', linspace(yLim_FR_RCS(1), yLim_FR_RCS(2), 7), 'yminortick', 'on');
     set(gca, 'xtick', xtick, 'xticklabel', xtickstr);
     text(-0.04, -0.13, sprintf('%s', datestr(data.mTime(1), 'yyyy-mm-dd')), 'Units', 'Normal', 'FontSize', 7);
     text(0.90, -0.13, sprintf('Version %s', processInfo.programVersion), 'Units', 'Normal', 'FontSize', 7);
@@ -250,12 +254,12 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis([0, 0.4]);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_RCS_FR);
+    ylim(yLim_FR_RCS);
     xlabel('UTC', 'FontSize', 7);
     ylabel('Height (m)', 'FontSize', 7);
     title(sprintf('Volume Depolarization Ratio at %snm from %s at %s', '355', taskInfo.pollyVersion, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none', 'FontSize', 7);
     set(gca, 'Box', 'on', 'TickDir', 'out');
-    set(gca, 'ytick', linspace(yLim_RCS_FR(1), yLim_RCS_FR(2), 7), 'yminortick', 'on');
+    set(gca, 'ytick', linspace(yLim_FR_RCS(1), yLim_FR_RCS(2), 7), 'yminortick', 'on');
     set(gca, 'xtick', xtick, 'xticklabel', xtickstr);
     text(-0.04, -0.13, sprintf('%s', datestr(data.mTime(1), 'yyyy-mm-dd')), 'Units', 'Normal', 'FontSize', 7);
     text(0.90, -0.13, sprintf('Version %s', processInfo.programVersion), 'Units', 'Normal', 'FontSize', 7);
@@ -287,11 +291,6 @@ elseif strcmpi(processInfo.visualizationMode, 'python')
 
     %% preparing the data
     [xtick, xtickstr] = timelabellayout(data.mTime, 'HH:MM');
-    flagChannel355 = config.isFR & config.is355nm & config.isTot;
-    flagChannel532 = config.isFR & config.is532nm & config.isTot;
-    flagChannel1064 = config.isFR & config.is1064nm & config.isTot;
-    flagChannel532NR = config.isNR & config.is532nm & config.isTot;
-    flagChannel355NR = config.isNR & config.is355nm & config.isTot;
     mTime = data.mTime;
     height = data.height;
     figDPI = processInfo.figDPI;
@@ -339,19 +338,9 @@ elseif strcmpi(processInfo.visualizationMode, 'python')
         RCS_NR_532 = NaN(size(data.signal, 2), size(data.signal, 3));
     end
 
-    yLim_FR = config.yLim_FR_RCS;
-    yLim_NR = config.yLim_NR_RCS;
-    volDepol_355 = data.volDepol_355;
-    volDepol_532 = data.volDepol_532;
-    RCS355FRColorRange = config.zLim_FR_RCS_355;
-    RCS532FRColorRange = config.zLim_FR_RCS_532;
-    RCS1064FRColorRange = config.zLim_FR_RCS_1064;
-    RCS355NRColorRange = config.zLim_NR_RCS_355;
-    RCS532NRColorRange = config.zLim_NR_RCS_355;
-
     %% display rcs 
     tmpFile = fullfile(tmpFolder, [basename(tempname), '.mat']);
-    save(tmpFile, 'figDPI', 'mTime', 'height', 'depCalMask', 'fogMask', 'yLim_FR', 'yLim_NR', 'RCS_FR_355', 'RCS_FR_532', 'RCS_FR_1064', 'RCS_NR_355', 'RCS_NR_532', 'volDepol_355', 'volDepol_532', 'processInfo', 'campaignInfo', 'taskInfo', 'xtick', 'xtickstr', 'RCS355FRColorRange', 'RCS532FRColorRange', 'RCS1064FRColorRange', 'RCS355NRColorRange', 'RCS532NRColorRange', '-v6');
+    save(tmpFile, 'figDPI', 'mTime', 'height', 'depCalMask', 'fogMask', 'yLim_FR_RCS', 'yLim_NR_RCS', 'yLim_FR_DR', 'RCS_FR_355', 'RCS_FR_532', 'RCS_FR_1064', 'RCS_NR_355', 'RCS_NR_532', 'volDepol_355', 'volDepol_532', 'processInfo', 'campaignInfo', 'taskInfo', 'xtick', 'xtickstr', 'RCS355FRColorRange', 'RCS532FRColorRange', 'RCS1064FRColorRange', 'RCS355NRColorRange', 'RCS532NRColorRange', '-v6');
     flag = system(sprintf('%s %s %s %s', fullfile(processInfo.pyBinDir, 'python'), fullfile(pyFolder, 'pollyxt_display_rcs.py'), tmpFile, saveFolder));
     if flag ~= 0
         warning('Error in executing %s', 'pollyxt_display_rcs.py');

--- a/lib/polly_general_func_lib/pollyxt_display_rcs.py
+++ b/lib/polly_general_func_lib/pollyxt_display_rcs.py
@@ -120,8 +120,9 @@ def pollyxt_display_rcs(tmpFile, saveFolder):
         fontname = mat['processInfo']['fontname'][0][0][0]
         dataFilename = mat['taskInfo']['dataFilename'][0][0][0]
         RCS355FRColorRange = mat['RCS355FRColorRange'][:][0]
-        yLim_FR = mat['yLim_FR'][:][0]
-        yLim_NR = mat['yLim_NR'][:][0]
+        yLim_FR_RCS = mat['yLim_FR_RCS'][:][0]
+        yLim_NR_RCS = mat['yLim_NR_RCS'][:][0]
+        yLim_NR_DR = mat['yLim_NR_DR'][:][0]
         RCS532FRColorRange = mat['RCS532FRColorRange'][:][0]
         RCS1064FRColorRange = mat['RCS1064FRColorRange'][:][0]
         RCS355NRColorRange = mat['RCS355NRColorRange'][:][0]
@@ -165,7 +166,7 @@ def pollyxt_display_rcs(tmpFile, saveFolder):
 
     ax.yaxis.set_major_locator(MultipleLocator(2500))
     ax.yaxis.set_minor_locator(MultipleLocator(500))
-    ax.set_ylim([yLim_FR[0], yLim_FR[1]])
+    ax.set_ylim([yLim_FR_RCS[0], yLim_FR_RCS[1]])
     ax.set_xticks(xtick.tolist())
     ax.set_xticklabels(celltolist(xticklabel))
     ax.tick_params(axis='both', which='major', labelsize=15,
@@ -212,7 +213,7 @@ def pollyxt_display_rcs(tmpFile, saveFolder):
 
     ax.yaxis.set_major_locator(MultipleLocator(2500))
     ax.yaxis.set_minor_locator(MultipleLocator(500))
-    ax.set_ylim([yLim_FR[0], yLim_FR[1]])
+    ax.set_ylim([yLim_FR_RCS[0], yLim_FR_RCS[1]])
     ax.set_xticks(xtick.tolist())
     ax.set_xticklabels(celltolist(xticklabel))
     ax.tick_params(axis='both', which='major', labelsize=15,
@@ -259,7 +260,7 @@ def pollyxt_display_rcs(tmpFile, saveFolder):
 
     ax.yaxis.set_major_locator(MultipleLocator(2500))
     ax.yaxis.set_minor_locator(MultipleLocator(500))
-    ax.set_ylim([yLim_FR[0], yLim_FR[1]])
+    ax.set_ylim([yLim_FR_RCS[0], yLim_FR_RCS[1]])
     ax.set_xticks(xtick.tolist())
     ax.set_xticklabels(celltolist(xticklabel))
     ax.tick_params(axis='both', which='major', labelsize=15,
@@ -306,7 +307,7 @@ def pollyxt_display_rcs(tmpFile, saveFolder):
 
     ax.yaxis.set_major_locator(MultipleLocator(1000))
     ax.yaxis.set_minor_locator(MultipleLocator(200))
-    ax.set_ylim([yLim_NR[0], yLim_NR[1]])
+    ax.set_ylim([yLim_NR_RCS[0], yLim_NR_RCS[1]])
     ax.set_xticks(xtick.tolist())
     ax.set_xticklabels(celltolist(xticklabel))
     ax.tick_params(axis='both', which='major', labelsize=15,
@@ -355,7 +356,7 @@ def pollyxt_display_rcs(tmpFile, saveFolder):
 
     ax.yaxis.set_major_locator(MultipleLocator(1000))
     ax.yaxis.set_minor_locator(MultipleLocator(200))
-    ax.set_ylim([yLim_NR[0], yLim_NR[1]])
+    ax.set_ylim([yLim_NR_RCS[0], yLim_NR_RCS[1]])
     ax.set_xticks(xtick.tolist())
     ax.set_xticklabels(celltolist(xticklabel))
     ax.tick_params(axis='both', which='major', labelsize=15,
@@ -401,7 +402,7 @@ def pollyxt_display_rcs(tmpFile, saveFolder):
 
     ax.yaxis.set_major_locator(MultipleLocator(2500))
     ax.yaxis.set_minor_locator(MultipleLocator(500))
-    ax.set_ylim([yLim_FR[0], yLim_FR[1]])
+    ax.set_ylim([yLim_FR_DR[0], yLim_FR_DR[1]])
     ax.set_xticks(xtick.tolist())
     ax.set_xticklabels(celltolist(xticklabel))
     ax.tick_params(axis='both', which='major', labelsize=15,
@@ -441,7 +442,7 @@ def pollyxt_display_rcs(tmpFile, saveFolder):
 
     ax.yaxis.set_major_locator(MultipleLocator(2500))
     ax.yaxis.set_minor_locator(MultipleLocator(500))
-    ax.set_ylim([yLim_FR[0], yLim_FR[1]])
+    ax.set_ylim([yLim_FR_DR[0], yLim_FR_DR[1]])
     ax.set_xticks(xtick.tolist())
     ax.set_xticklabels(celltolist(xticklabel))
     ax.tick_params(axis='both', which='major', labelsize=15,

--- a/lib/pollyxt_cge_func_lib/pollyxt_cge_display_rcs.m
+++ b/lib/pollyxt_cge_func_lib/pollyxt_cge_display_rcs.m
@@ -14,7 +14,23 @@ function pollyxt_cge_display_rcs(data, taskInfo, config)
 
 global defaults processInfo campaignInfo
 
+yLim_FR_RCS = config.yLim_FR_RCS;
+yLim_NR_RCS = config.yLim_NR_RCS;
+yLim_FR_DR = config.yLim_FR_DR;
+volDepol_532 = data.volDepol_532;
+RCS355FRColorRange = config.zLim_FR_RCS_355;
+RCS532FRColorRange = config.zLim_FR_RCS_532;
+RCS1064FRColorRange = config.zLim_FR_RCS_1064;
+RCS355NRColorRange = config.zLim_NR_RCS_355;
+RCS532NRColorRange = config.zLim_NR_RCS_355;
+flagChannel355 = config.isFR & config.is355nm & config.isTot;
+flagChannel532 = config.isFR & config.is532nm & config.isTot;
+flagChannel1064 = config.isFR & config.is1064nm & config.isTot;
+flagChannel532NR = config.isNR & config.is532nm & config.isTot;
+flagChannel355NR = config.isNR & config.is355nm & config.isTot;
+
 if strcmpi(processInfo.visualizationMode, 'matlab')
+
     %% parameter initialize
     fileRCS355FR = fullfile(processInfo.pic_folder, campaignInfo.name, datestr(data.mTime(1), 'yyyy'), datestr(data.mTime(1), 'mm'), datestr(data.mTime(1), 'dd'), sprintf('%s_RCS_FR_355.png', rmext(taskInfo.dataFilename)));
     fileRCS532FR = fullfile(processInfo.pic_folder, campaignInfo.name, datestr(data.mTime(1), 'yyyy'), datestr(data.mTime(1), 'mm'), datestr(data.mTime(1), 'dd'), sprintf('%s_RCS_FR_532.png', rmext(taskInfo.dataFilename)));
@@ -22,19 +38,6 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     fileRCS355NR = fullfile(processInfo.pic_folder, campaignInfo.name, datestr(data.mTime(1), 'yyyy'), datestr(data.mTime(1), 'mm'), datestr(data.mTime(1), 'dd'), sprintf('%s_RCS_NR_355.png', rmext(taskInfo.dataFilename)));
     fileRCS532NR = fullfile(processInfo.pic_folder, campaignInfo.name, datestr(data.mTime(1), 'yyyy'), datestr(data.mTime(1), 'mm'), datestr(data.mTime(1), 'dd'), sprintf('%s_RCS_NR_532.png', rmext(taskInfo.dataFilename)));
     fileVolDepol532 = fullfile(processInfo.pic_folder, campaignInfo.name, datestr(data.mTime(1), 'yyyy'), datestr(data.mTime(1), 'mm'), datestr(data.mTime(1), 'dd'), sprintf('%s_VDR_532.png', rmext(taskInfo.dataFilename)));
-    flagChannel355 = config.isFR & config.is355nm & config.isTot;
-    flagChannel532 = config.isFR & config.is532nm & config.isTot;
-    flagChannel1064 = config.isFR & config.is1064nm & config.isTot;
-    flagChannel532NR = config.isNR & config.is532nm & config.isTot;
-    flagChannel355NR = config.isNR & config.is355nm & config.isTot;
-
-    yLim_FR = config.yLim_FR_RCS;
-    yLim_NR = config.yLim_NR_RCS;
-    RCS355FRColorRange = config.zLim_FR_RCS_355;
-    RCS532FRColorRange = config.zLim_FR_RCS_532;
-    RCS1064FRColorRange = config.zLim_FR_RCS_1064;
-    RCS355NRColorRange = config.zLim_NR_RCS_355;
-    RCS532NRColorRange = config.zLim_NR_RCS_532;
 
     %% visualization
     load('myjet_colormap.mat')   % load colormap
@@ -51,12 +54,12 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis(RCS355FRColorRange);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_RCS_FR);
+    ylim(yLim_FR_RCS);
     xlabel('UTC', 'FontSize', 7);
     ylabel('Height (m)', 'FontSize', 7);
     title(sprintf('Range-Corrected Signal at %snm Far-Range from %s at %s', '355', taskInfo.pollyVersion, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none', 'FontSize', 7);
     set(gca, 'Box', 'on', 'TickDir', 'out');
-    set(gca, 'ytick', linspace(yLim_RCS_FR(1), yLim_RCS_FR(2), 7), 'yminortick', 'on', 'FontSize', 7);
+    set(gca, 'ytick', linspace(yLim_FR_RCS(1), yLim_FR_RCS(2), 7), 'yminortick', 'on', 'FontSize', 7);
     set(gca, 'xtick', xtick, 'xticklabel', xtickstr);
     text(-0.04, -0.13, sprintf('%s', datestr(data.mTime(1), 'yyyy-mm-dd')), 'Units', 'Normal', 'FontSize', 7);
     text(0.90, -0.13, sprintf('Version %s', processInfo.programVersion), 'Units', 'Normal', 'FontSize', 7);
@@ -84,12 +87,12 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis(RCS532FRColorRange);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_RCS_FR);
+    ylim(yLim_FR_RCS);
     xlabel('UTC', 'FontSize', 7);
     ylabel('Height (m)', 'FontSize', 7);
     title(sprintf('Range-Corrected Signal at %snm Far-Range from %s at %s', '532', taskInfo.pollyVersion, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none', 'FontSize', 7);
     set(gca, 'Box', 'on', 'TickDir', 'out');
-    set(gca, 'ytick', linspace(yLim_RCS_FR(1), yLim_RCS_FR(2), 7), 'yminortick', 'on', 'FontSize', 7);
+    set(gca, 'ytick', linspace(yLim_FR_RCS(1), yLim_FR_RCS(2), 7), 'yminortick', 'on', 'FontSize', 7);
     set(gca, 'xtick', xtick, 'xticklabel', xtickstr);
     text(-0.04, -0.13, sprintf('%s', datestr(data.mTime(1), 'yyyy-mm-dd')), 'Units', 'Normal', 'FontSize', 7);
     text(0.90, -0.13, sprintf('Version %s', processInfo.programVersion), 'Units', 'Normal', 'FontSize', 7);
@@ -117,12 +120,12 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis(RCS1064FRColorRange);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_RCS_FR);
+    ylim(yLim_FR_RCS);
     xlabel('UTC', 'FontSize', 7);
     ylabel('Height (m)', 'FontSize', 7);
     title(sprintf('Range-Corrected Signal at %snm Far-Range from %s at %s', '1064', taskInfo.pollyVersion, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none', 'FontSize', 7);
     set(gca, 'Box', 'on', 'TickDir', 'out');
-    set(gca, 'ytick', linspace(yLim_RCS_FR(1), yLim_RCS_FR(2), 7), 'yminortick', 'on', 'FontSize', 7);
+    set(gca, 'ytick', linspace(yLim_FR_RCS(1), yLim_FR_RCS(2), 7), 'yminortick', 'on', 'FontSize', 7);
     set(gca, 'xtick', xtick, 'xticklabel', xtickstr);
     text(-0.04, -0.13, sprintf('%s', datestr(data.mTime(1), 'yyyy-mm-dd')), 'Units', 'Normal', 'FontSize', 7);
     text(0.90, -0.13, sprintf('Version %s', processInfo.programVersion), 'Units', 'Normal', 'FontSize', 7);
@@ -150,12 +153,12 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis(RCS355NRColorRange);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_RCS_NR);
+    ylim(yLim_NR_RCS);
     xlabel('UTC', 'FontSize', 7);
     ylabel('Height (m)', 'FontSize', 7);
     title(sprintf('Range-Corrected Signal at %snm Near-Range from %s at %s', '355', taskInfo.pollyVersion, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none', 'FontSize', 7);
     set(gca, 'Box', 'on', 'TickDir', 'out');
-    set(gca, 'ytick', yLim_RCS_NR(1):1000:yLim_RCS_NR(2), 'yminortick', 'on', 'FontSize', 7);
+    set(gca, 'ytick', yLim_NR_RCS(1):1000:yLim_NR_RCS(2), 'yminortick', 'on', 'FontSize', 7);
     set(gca, 'xtick', xtick, 'xticklabel', xtickstr);
     text(-0.04, -0.13, sprintf('%s', datestr(data.mTime(1), 'yyyy-mm-dd')), 'Units', 'Normal', 'FontSize', 7);
     text(0.90, -0.13, sprintf('Version %s', processInfo.programVersion), 'Units', 'Normal', 'FontSize', 7);
@@ -183,12 +186,12 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis(RCS532NRColorRange);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_RCS_NR);
+    ylim(yLim_NR_RCS);
     xlabel('UTC', 'FontSize', 7);
     ylabel('Height (m)', 'FontSize', 7);
     title(sprintf('Range-Corrected Signal at %snm Near-Range from %s at %s', '532', taskInfo.pollyVersion, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none', 'FontSize', 7);
     set(gca, 'Box', 'on', 'TickDir', 'out');
-    set(gca, 'ytick', yLim_RCS_NR(1):1000:yLim_RCS_NR(2), 'yminortick', 'on', 'FontSize', 7);
+    set(gca, 'ytick', yLim_NR_RCS(1):1000:yLim_NR_RCS(2), 'yminortick', 'on', 'FontSize', 7);
     set(gca, 'xtick', xtick, 'xticklabel', xtickstr);
     text(-0.04, -0.13, sprintf('%s', datestr(data.mTime(1), 'yyyy-mm-dd')), 'Units', 'Normal', 'FontSize', 7);
     text(0.90, -0.13, sprintf('Version %s', processInfo.programVersion), 'Units', 'Normal', 'FontSize', 7);
@@ -216,12 +219,12 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis([0, 0.4]);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_RCS_FR);
+    ylim(yLim_FR_RCS);
     xlabel('UTC', 'FontSize', 7);
     ylabel('Height (m)', 'FontSize', 7);
     title(sprintf('Volume Depolarization Ratio at %snm from %s at %s', '532', taskInfo.pollyVersion, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none', 'FontSize', 7);
     set(gca, 'Box', 'on', 'TickDir', 'out');
-    set(gca, 'ytick', linspace(yLim_RCS_FR(1), yLim_RCS_FR(2), 7), 'yminortick', 'on');
+    set(gca, 'ytick', linspace(yLim_FR_RCS(1), yLim_FR_RCS(2), 7), 'yminortick', 'on');
     set(gca, 'xtick', xtick, 'xticklabel', xtickstr);
     text(-0.04, -0.13, sprintf('%s', datestr(data.mTime(1), 'yyyy-mm-dd')), 'Units', 'Normal', 'FontSize', 7);
     text(0.90, -0.13, sprintf('Version %s', processInfo.programVersion), 'Units', 'Normal', 'FontSize', 7);
@@ -253,11 +256,6 @@ elseif strcmpi(processInfo.visualizationMode, 'python')
 
     %% preparing the data
     [xtick, xtickstr] = timelabellayout(data.mTime, 'HH:MM');
-    flagChannel355 = config.isFR & config.is355nm & config.isTot;
-    flagChannel532 = config.isFR & config.is532nm & config.isTot;
-    flagChannel1064 = config.isFR & config.is1064nm & config.isTot;
-    flagChannel532NR = config.isNR & config.is532nm & config.isTot;
-    flagChannel355NR = config.isNR & config.is355nm & config.isTot;
     mTime = data.mTime;
     height = data.height;
     figDPI = processInfo.figDPI;
@@ -304,18 +302,10 @@ elseif strcmpi(processInfo.visualizationMode, 'python')
         RCS_NR_532 = NaN(size(data.signal, 2), size(data.signal, 3));
     end
 
-    yLim_FR = config.yLim_FR_RCS;
-    yLim_NR = config.yLim_NR_RCS;
-    volDepol_532 = data.volDepol_532;
-    RCS355FRColorRange = config.zLim_FR_RCS_355;
-    RCS532FRColorRange = config.zLim_FR_RCS_532;
-    RCS1064FRColorRange = config.zLim_FR_RCS_1064;
-    RCS355NRColorRange = config.zLim_NR_RCS_355;
-    RCS532NRColorRange = config.zLim_NR_RCS_355;
-
     %% display rcs 
     tmpFile = fullfile(tmpFolder, [basename(tempname), '.mat']);
-    save(tmpFile, 'figDPI', 'mTime', 'height', 'depCalMask', 'fogMask', 'yLim_FR', 'yLim_NR', 'RCS_FR_355', 'RCS_FR_532', 'RCS_FR_1064', 'RCS_NR_355', 'RCS_NR_532', 'volDepol_532', 'processInfo', 'campaignInfo', 'taskInfo', 'xtick', 'xtickstr', 'RCS355FRColorRange', 'RCS532FRColorRange', 'RCS1064FRColorRange', 'RCS355NRColorRange', 'RCS532NRColorRange', '-v6');
+    save(tmpFile, 'figDPI', 'mTime', 'height', 'depCalMask', 'fogMask', 'yLim_FR_RCS', 'yLim_NR_RCS', 'yLim_FR_DR', 'RCS_FR_355', 'RCS_FR_532', 'RCS_FR_1064', 'RCS_NR_355', 'RCS_NR_532', 'volDepol_532_RCS', 'processInfo', 'campaignInfo', 'taskInfo', 'xtick', 'xtickstr', 'RCS355FRColorRange', 'RCS532FRColorRange', 'RCS1064FRColorRange', 'RCS355NRColorRange', 'RCS532NRColorRange', '-v6');
+    save(tmpFile, 'figDPI', 'mTime', 'height', 'depCalMask', 'fogMask', 'yLim_FR_RCS', 'yLim_NR_RCS', 'yLim_FR_DR', 'RCS_FR_355', 'RCS_FR_532', 'RCS_FR_1064', 'RCS_NR_355', 'RCS_NR_532', 'volDepol_5FR_DR', 'processInfo', 'campaignInfo', 'taskInfo', 'xtick', 'xtickstr', 'RCS355FRColorRange', 'RCS532FRColorRange', 'RCS1064FRColorRange', 'RCS355NRColorRange', 'RCS532NRColorRange', '-v6');
     flag = system(sprintf('%s %s %s %s', fullfile(processInfo.pyBinDir, 'python'), fullfile(pyFolder, 'pollyxt_cge_display_rcs.py'), tmpFile, saveFolder));
     if flag ~= 0
         warning('Error in executing %s', 'pollyxt_cge_display_rcs.py');

--- a/lib/pollyxt_cge_func_lib/pollyxt_cge_display_rcs.py
+++ b/lib/pollyxt_cge_func_lib/pollyxt_cge_display_rcs.py
@@ -118,8 +118,9 @@ def pollyxt_cge_display_rcs(tmpFile, saveFolder):
         fontname = mat['processInfo']['fontname'][0][0][0]
         dataFilename = mat['taskInfo']['dataFilename'][0][0][0]
         RCS355FRColorRange = mat['RCS355FRColorRange'][:][0]
-        yLim_FR = mat['yLim_FR'][:][0]
-        yLim_NR = mat['yLim_NR'][:][0]
+        yLim_FR_RCS = mat['yLim_FR_RCS'][:][0]
+        yLim_NR_RCS = mat['yLim_NR_RCS'][:][0]
+        yLim_FR_DR = mat['yLim_FR_DR'][:][0]
         RCS532FRColorRange = mat['RCS532FRColorRange'][:][0]
         RCS1064FRColorRange = mat['RCS1064FRColorRange'][:][0]
         RCS532NRColorRange = mat['RCS532NRColorRange'][:][0]
@@ -159,7 +160,7 @@ def pollyxt_cge_display_rcs(tmpFile, saveFolder):
 
     ax.yaxis.set_major_locator(MultipleLocator(2500))
     ax.yaxis.set_minor_locator(MultipleLocator(500))
-    ax.set_ylim([yLim_FR[0], yLim_FR[1]])
+    ax.set_ylim([yLim_FR_RCS[0], yLim_FR_RCS[1]])
     ax.set_xticks(xtick.tolist())
     ax.set_xticklabels(celltolist(xticklabel))
     ax.tick_params(axis='both', which='major', labelsize=15,
@@ -206,7 +207,7 @@ def pollyxt_cge_display_rcs(tmpFile, saveFolder):
 
     ax.yaxis.set_major_locator(MultipleLocator(2500))
     ax.yaxis.set_minor_locator(MultipleLocator(500))
-    ax.set_ylim([yLim_FR[0], yLim_FR[1]])
+    ax.set_ylim([yLim_FR_RCS[0], yLim_FR_RCS[1]])
     ax.set_xticks(xtick.tolist())
     ax.set_xticklabels(celltolist(xticklabel))
     ax.tick_params(axis='both', which='major', labelsize=15,
@@ -253,7 +254,7 @@ def pollyxt_cge_display_rcs(tmpFile, saveFolder):
 
     ax.yaxis.set_major_locator(MultipleLocator(2500))
     ax.yaxis.set_minor_locator(MultipleLocator(500))
-    ax.set_ylim([yLim_FR[0], yLim_FR[1]])
+    ax.set_ylim([yLim_FR_RCS[0], yLim_FR_RCS[1]])
     ax.set_xticks(xtick.tolist())
     ax.set_xticklabels(celltolist(xticklabel))
     ax.tick_params(axis='both', which='major', labelsize=15,
@@ -302,7 +303,7 @@ def pollyxt_cge_display_rcs(tmpFile, saveFolder):
 
     ax.yaxis.set_major_locator(MultipleLocator(1000))
     ax.yaxis.set_minor_locator(MultipleLocator(200))
-    ax.set_ylim([yLim_NR[0], yLim_NR[1]])
+    ax.set_ylim([yLim_NR_RCS[0], yLim_NR_RCS[1]])
     ax.set_xticks(xtick.tolist())
     ax.set_xticklabels(celltolist(xticklabel))
     ax.tick_params(axis='both', which='major', labelsize=15,
@@ -349,7 +350,7 @@ def pollyxt_cge_display_rcs(tmpFile, saveFolder):
 
     ax.yaxis.set_major_locator(MultipleLocator(2500))
     ax.yaxis.set_minor_locator(MultipleLocator(500))
-    ax.set_ylim([yLim_FR[0], yLim_FR[1]])
+    ax.set_ylim([yLim_FR_DR[0], yLim_FR_DR[1]])
     ax.set_xticks(xtick.tolist())
     ax.set_xticklabels(celltolist(xticklabel))
     ax.tick_params(axis='both', which='major', labelsize=15,

--- a/lib/pollyxt_dwd_func_lib/pollyxt_dwd_display_rcs.m
+++ b/lib/pollyxt_dwd_func_lib/pollyxt_dwd_display_rcs.m
@@ -14,6 +14,22 @@ function pollyxt_dwd_display_rcs(data, taskInfo, config)
 
 global defaults processInfo campaignInfo
 
+flagChannel355 = config.isFR & config.is355nm & config.isTot;
+flagChannel532 = config.isFR & config.is532nm & config.isTot;
+flagChannel1064 = config.isFR & config.is1064nm & config.isTot;
+flagChannel532NR = config.isNR & config.is532nm & config.isTot;
+flagChannel355NR = config.isNR & config.is355nm & config.isTot;
+
+yLim_FR_RCS = config.yLim_FR_RCS;
+yLim_NR_RCS = config.yLim_NR_RCS;
+yLim_FR_DR = config.yLim_FR_DR;
+volDepol_532 = data.volDepol_532;
+RCS355FRColorRange = config.zLim_FR_RCS_355;
+RCS532FRColorRange = config.zLim_FR_RCS_532;
+RCS1064FRColorRange = config.zLim_FR_RCS_1064;
+RCS355NRColorRange = config.zLim_NR_RCS_355;
+RCS532NRColorRange = config.zLim_NR_RCS_532;
+
 if strcmpi(processInfo.visualizationMode, 'matlab')
     %% parameter initialize
     fileRCS355FR = fullfile(processInfo.pic_folder, campaignInfo.name, datestr(data.mTime(1), 'yyyy'), datestr(data.mTime(1), 'mm'), datestr(data.mTime(1), 'dd'), sprintf('%s_RCS_FR_355.png', rmext(taskInfo.dataFilename)));
@@ -22,19 +38,6 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     fileRCS355NR = fullfile(processInfo.pic_folder, campaignInfo.name, datestr(data.mTime(1), 'yyyy'), datestr(data.mTime(1), 'mm'), datestr(data.mTime(1), 'dd'), sprintf('%s_RCS_NR_355.png', rmext(taskInfo.dataFilename)));
     fileRCS532NR = fullfile(processInfo.pic_folder, campaignInfo.name, datestr(data.mTime(1), 'yyyy'), datestr(data.mTime(1), 'mm'), datestr(data.mTime(1), 'dd'), sprintf('%s_RCS_NR_532.png', rmext(taskInfo.dataFilename)));
     fileVolDepol532 = fullfile(processInfo.pic_folder, campaignInfo.name, datestr(data.mTime(1), 'yyyy'), datestr(data.mTime(1), 'mm'), datestr(data.mTime(1), 'dd'), sprintf('%s_VDR_532.png', rmext(taskInfo.dataFilename)));
-    flagChannel355 = config.isFR & config.is355nm & config.isTot;
-    flagChannel532 = config.isFR & config.is532nm & config.isTot;
-    flagChannel1064 = config.isFR & config.is1064nm & config.isTot;
-    flagChannel532NR = config.isNR & config.is532nm & config.isTot;
-    flagChannel355NR = config.isNR & config.is355nm & config.isTot;
-
-    yLim_FR = config.yLim_FR_RCS;
-    yLim_NR = config.yLim_NR_RCS;
-    RCS355FRColorRange = config.zLim_FR_RCS_355;
-    RCS532FRColorRange = config.zLim_FR_RCS_532;
-    RCS1064FRColorRange = config.zLim_FR_RCS_1064;
-    RCS355NRColorRange = config.zLim_NR_RCS_355;
-    RCS532NRColorRange = config.zLim_NR_RCS_532;
 
     %% visualization
     load('myjet_colormap.mat')   % load colormap
@@ -51,12 +54,12 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis(RCS355FRColorRange);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_RCS_FR);
+    ylim(yLim_FR_RCS);
     xlabel('UTC', 'FontSize', 7);
     ylabel('Height (m)', 'FontSize', 7);
     title(sprintf('Range-Corrected Signal at %snm Far-Range from %s at %s', '355', taskInfo.pollyVersion, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none', 'FontSize', 7);
     set(gca, 'Box', 'on', 'TickDir', 'out');
-    set(gca, 'ytick', linspace(yLim_RCS_FR(1), yLim_RCS_FR(2), 7), 'yminortick', 'on', 'FontSize', 7);
+    set(gca, 'ytick', linspace(yLim_FR_RCS(1), yLim_FR_RCS(2), 7), 'yminortick', 'on', 'FontSize', 7);
     set(gca, 'xtick', xtick, 'xticklabel', xtickstr);
     text(-0.04, -0.13, sprintf('%s', datestr(data.mTime(1), 'yyyy-mm-dd')), 'Units', 'Normal', 'FontSize', 7);
     text(0.90, -0.13, sprintf('Version %s', processInfo.programVersion), 'Units', 'Normal', 'FontSize', 7);
@@ -84,12 +87,12 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis(RCS532FRColorRange);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_RCS_FR);
+    ylim(yLim_FR_RCS);
     xlabel('UTC', 'FontSize', 7);
     ylabel('Height (m)', 'FontSize', 7);
     title(sprintf('Range-Corrected Signal at %snm Far-Range from %s at %s', '532', taskInfo.pollyVersion, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none', 'FontSize', 7);
     set(gca, 'Box', 'on', 'TickDir', 'out');
-    set(gca, 'ytick', linspace(yLim_RCS_FR(1), yLim_RCS_FR(2), 7), 'yminortick', 'on', 'FontSize', 7);
+    set(gca, 'ytick', linspace(yLim_FR_RCS(1), yLim_FR_RCS(2), 7), 'yminortick', 'on', 'FontSize', 7);
     set(gca, 'xtick', xtick, 'xticklabel', xtickstr);
     text(-0.04, -0.13, sprintf('%s', datestr(data.mTime(1), 'yyyy-mm-dd')), 'Units', 'Normal', 'FontSize', 7);
     text(0.90, -0.13, sprintf('Version %s', processInfo.programVersion), 'Units', 'Normal', 'FontSize', 7);
@@ -117,12 +120,12 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis(RCS1064FRColorRange);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_RCS_FR);
+    ylim(yLim_FR_RCS);
     xlabel('UTC', 'FontSize', 7);
     ylabel('Height (m)', 'FontSize', 7);
     title(sprintf('Range-Corrected Signal at %snm Far-Range from %s at %s', '1064', taskInfo.pollyVersion, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none', 'FontSize', 7);
     set(gca, 'Box', 'on', 'TickDir', 'out');
-    set(gca, 'ytick', linspace(yLim_RCS_FR(1), yLim_RCS_FR(2), 7), 'yminortick', 'on', 'FontSize', 7);
+    set(gca, 'ytick', linspace(yLim_FR_RCS(1), yLim_FR_RCS(2), 7), 'yminortick', 'on', 'FontSize', 7);
     set(gca, 'xtick', xtick, 'xticklabel', xtickstr);
     text(-0.04, -0.13, sprintf('%s', datestr(data.mTime(1), 'yyyy-mm-dd')), 'Units', 'Normal', 'FontSize', 7);
     text(0.90, -0.13, sprintf('Version %s', processInfo.programVersion), 'Units', 'Normal', 'FontSize', 7);
@@ -150,12 +153,12 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis(RCS355NRColorRange);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_RCS_NR);
+    ylim(yLim_NR_RCS);
     xlabel('UTC', 'FontSize', 7);
     ylabel('Height (m)', 'FontSize', 7);
     title(sprintf('Range-Corrected Signal at %snm Near-Range from %s at %s', '355', taskInfo.pollyVersion, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none', 'FontSize', 7);
     set(gca, 'Box', 'on', 'TickDir', 'out');
-    set(gca, 'ytick', yLim_RCS_NR(1):1000:yLim_RCS_NR(2), 'yminortick', 'on', 'FontSize', 7);
+    set(gca, 'ytick', yLim_NR_RCS(1):1000:yLim_NR_RCS(2), 'yminortick', 'on', 'FontSize', 7);
     set(gca, 'xtick', xtick, 'xticklabel', xtickstr);
     text(-0.04, -0.13, sprintf('%s', datestr(data.mTime(1), 'yyyy-mm-dd')), 'Units', 'Normal', 'FontSize', 7);
     text(0.90, -0.13, sprintf('Version %s', processInfo.programVersion), 'Units', 'Normal', 'FontSize', 7);
@@ -183,12 +186,12 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis(RCS532NRColorRange);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_RCS_NR);
+    ylim(yLim_NR_RCS);
     xlabel('UTC', 'FontSize', 7);
     ylabel('Height (m)', 'FontSize', 7);
     title(sprintf('Range-Corrected Signal at %snm Near-Range from %s at %s', '532', taskInfo.pollyVersion, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none', 'FontSize', 7);
     set(gca, 'Box', 'on', 'TickDir', 'out');
-    set(gca, 'ytick', yLim_RCS_NR(1):1000:yLim_RCS_NR(2), 'yminortick', 'on', 'FontSize', 7);
+    set(gca, 'ytick', yLim_NR_RCS(1):1000:yLim_NR_RCS(2), 'yminortick', 'on', 'FontSize', 7);
     set(gca, 'xtick', xtick, 'xticklabel', xtickstr);
     text(-0.04, -0.13, sprintf('%s', datestr(data.mTime(1), 'yyyy-mm-dd')), 'Units', 'Normal', 'FontSize', 7);
     text(0.90, -0.13, sprintf('Version %s', processInfo.programVersion), 'Units', 'Normal', 'FontSize', 7);
@@ -216,12 +219,12 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis([0, 0.4]);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_RCS_FR);
+    ylim(yLim_FR_DR);
     xlabel('UTC', 'FontSize', 7);
     ylabel('Height (m)', 'FontSize', 7);
     title(sprintf('Volume Depolarization Ratio at %snm from %s at %s', '532', taskInfo.pollyVersion, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none', 'FontSize', 7);
     set(gca, 'Box', 'on', 'TickDir', 'out');
-    set(gca, 'ytick', linspace(yLim_RCS_FR(1), yLim_RCS_FR(2), 7), 'yminortick', 'on');
+    set(gca, 'ytick', linspace(yLim_FR_DR(1), yLim_FR_DR(2), 7), 'yminortick', 'on');
     set(gca, 'xtick', xtick, 'xticklabel', xtickstr);
     text(-0.04, -0.13, sprintf('%s', datestr(data.mTime(1), 'yyyy-mm-dd')), 'Units', 'Normal', 'FontSize', 7);
     text(0.90, -0.13, sprintf('Version %s', processInfo.programVersion), 'Units', 'Normal', 'FontSize', 7);
@@ -253,11 +256,6 @@ elseif strcmpi(processInfo.visualizationMode, 'python')
 
     %% preparing the data
     [xtick, xtickstr] = timelabellayout(data.mTime, 'HH:MM');
-    flagChannel355 = config.isFR & config.is355nm & config.isTot;
-    flagChannel532 = config.isFR & config.is532nm & config.isTot;
-    flagChannel1064 = config.isFR & config.is1064nm & config.isTot;
-    flagChannel532NR = config.isNR & config.is532nm & config.isTot;
-    flagChannel355NR = config.isNR & config.is355nm & config.isTot;
     mTime = data.mTime;
     height = data.height;
     figDPI = processInfo.figDPI;
@@ -304,18 +302,10 @@ elseif strcmpi(processInfo.visualizationMode, 'python')
         RCS_NR_532 = NaN(size(data.signal, 2), size(data.signal, 3));
     end
 
-    yLim_FR = config.yLim_FR_RCS;
-    yLim_NR = config.yLim_NR_RCS;
-    volDepol_532 = data.volDepol_532;
-    RCS355FRColorRange = config.zLim_FR_RCS_355;
-    RCS532FRColorRange = config.zLim_FR_RCS_532;
-    RCS1064FRColorRange = config.zLim_FR_RCS_1064;
-    RCS355NRColorRange = config.zLim_NR_RCS_355;
-    RCS532NRColorRange = config.zLim_NR_RCS_355;
-
     %% display rcs 
     tmpFile = fullfile(tmpFolder, [basename(tempname), '.mat']);
-    save(tmpFile, 'figDPI', 'mTime', 'height', 'depCalMask', 'fogMask', 'yLim_FR', 'yLim_NR', 'RCS_FR_355', 'RCS_FR_532', 'RCS_FR_1064', 'RCS_NR_355', 'RCS_NR_532', 'volDepol_532', 'processInfo', 'campaignInfo', 'taskInfo', 'xtick', 'xtickstr', 'RCS355FRColorRange', 'RCS532FRColorRange', 'RCS1064FRColorRange', 'RCS355NRColorRange', 'RCS532NRColorRange', '-v6');
+    save(tmpFile, 'figDPI', 'mTime', 'height', 'depCalMask', 'fogMask', 'yLim_FR_RCS', 'yLim_NR_RCS', 'yLim_FR_DR', 'RCS_FR_355', 'RCS_FR_532', 'RCS_FR_1064', 'RCS_NR_355', 'RCS_NR_532', 'volDepol_532', 'processInfo', 'campaignInfo', 'taskInfo', 'xtick', 'xtickstr', 'RCS355FRColorRange', 'RCS532FRColorRange', 'RCS1064FRColorRange', 'RCS355NRColorRange', 'RCS532NRColorRange', '-v6');
+    save(tmpFile, 'figDPI', 'mTime', 'height', 'depCalMask', 'fogMask', 'yLim_FR_RCS', 'yLim_NR_RCS', 'RCS_FR_355', 'RCS_FR_532', 'RCS_FR_1064', 'RCS_NR_355', 'RCS_NR_532', 'volDepol_532', 'processInfo', 'campaignInfo', 'taskInfo', 'xtick', 'xtickstr', 'RCS355FRColorRange', 'RCS532FRColorRange', 'RCS1064FRColorRange', 'RCS355NRColorRange', 'RCS532NRColorRange', '-v6');
     flag = system(sprintf('%s %s %s %s', fullfile(processInfo.pyBinDir, 'python'), fullfile(pyFolder, 'pollyxt_dwd_display_rcs.py'), tmpFile, saveFolder));
     if flag ~= 0
         warning('Error in executing %s', 'pollyxt_dwd_display_rcs.py');

--- a/lib/pollyxt_dwd_func_lib/pollyxt_dwd_display_rcs.py
+++ b/lib/pollyxt_dwd_func_lib/pollyxt_dwd_display_rcs.py
@@ -118,8 +118,9 @@ def pollyxt_dwd_display_rcs(tmpFile, saveFolder):
         fontname = mat['processInfo']['fontname'][0][0][0]
         dataFilename = mat['taskInfo']['dataFilename'][0][0][0]
         RCS355FRColorRange = mat['RCS355FRColorRange'][:][0]
-        yLim_FR = mat['yLim_FR'][:][0]
-        yLim_NR = mat['yLim_NR'][:][0]
+        yLim_FR_RCS = mat['yLim_FR_RCS'][:][0]
+        yLim_NR_RCS = mat['yLim_NR_RCS'][:][0]
+        yLim_FR_DR = mat['yLim_FR_DR'][:][0]
         RCS532FRColorRange = mat['RCS532FRColorRange'][:][0]
         RCS1064FRColorRange = mat['RCS1064FRColorRange'][:][0]
         RCS532NRColorRange = mat['RCS532NRColorRange'][:][0]
@@ -159,7 +160,7 @@ def pollyxt_dwd_display_rcs(tmpFile, saveFolder):
 
     ax.yaxis.set_major_locator(MultipleLocator(2500))
     ax.yaxis.set_minor_locator(MultipleLocator(500))
-    ax.set_ylim([yLim_FR[0], yLim_FR[1]])
+    ax.set_ylim([yLim_FR_RCS[0], yLim_FR_RCS[1]])
     ax.set_xticks(xtick.tolist())
     ax.set_xticklabels(celltolist(xticklabel))
     ax.tick_params(axis='both', which='major', labelsize=15,
@@ -206,7 +207,7 @@ def pollyxt_dwd_display_rcs(tmpFile, saveFolder):
 
     ax.yaxis.set_major_locator(MultipleLocator(2500))
     ax.yaxis.set_minor_locator(MultipleLocator(500))
-    ax.set_ylim([yLim_FR[0], yLim_FR[1]])
+    ax.set_ylim([yLim_FR_RCS[0], yLim_FR_RCS[1]])
     ax.set_xticks(xtick.tolist())
     ax.set_xticklabels(celltolist(xticklabel))
     ax.tick_params(axis='both', which='major', labelsize=15,
@@ -253,7 +254,7 @@ def pollyxt_dwd_display_rcs(tmpFile, saveFolder):
 
     ax.yaxis.set_major_locator(MultipleLocator(2500))
     ax.yaxis.set_minor_locator(MultipleLocator(500))
-    ax.set_ylim([yLim_FR[0], yLim_FR[1]])
+    ax.set_ylim([yLim_FR_RCS[0], yLim_FR_RCS[1]])
     ax.set_xticks(xtick.tolist())
     ax.set_xticklabels(celltolist(xticklabel))
     ax.tick_params(axis='both', which='major', labelsize=15,
@@ -302,7 +303,7 @@ def pollyxt_dwd_display_rcs(tmpFile, saveFolder):
 
     ax.yaxis.set_major_locator(MultipleLocator(1000))
     ax.yaxis.set_minor_locator(MultipleLocator(200))
-    ax.set_ylim([yLim_NR[0], yLim_NR[1]])
+    ax.set_ylim([yLim_NR_RCS[0], yLim_NR_RCS[1]])
     ax.set_xticks(xtick.tolist())
     ax.set_xticklabels(celltolist(xticklabel))
     ax.tick_params(axis='both', which='major', labelsize=15,
@@ -349,7 +350,7 @@ def pollyxt_dwd_display_rcs(tmpFile, saveFolder):
 
     ax.yaxis.set_major_locator(MultipleLocator(2500))
     ax.yaxis.set_minor_locator(MultipleLocator(500))
-    ax.set_ylim([yLim_FR[0], yLim_FR[1]])
+    ax.set_ylim([yLim_FR_DR[0], yLim_FR_DR[1]])
     ax.set_xticks(xtick.tolist())
     ax.set_xticklabels(celltolist(xticklabel))
     ax.tick_params(axis='both', which='major', labelsize=15,

--- a/lib/pollyxt_ift_func_lib/pollyxt_ift_display_rcs.m
+++ b/lib/pollyxt_ift_func_lib/pollyxt_ift_display_rcs.m
@@ -14,6 +14,22 @@ function pollyxt_ift_display_rcs(data, taskInfo, config)
 
 global defaults processInfo campaignInfo
 
+flagChannel355 = config.isFR & config.is355nm & config.isTot;
+flagChannel532 = config.isFR & config.is532nm & config.isTot;
+flagChannel1064 = config.isFR & config.is1064nm & config.isTot;
+flagChannel532NR = config.isNR & config.is532nm & config.isTot;
+flagChannel355NR = config.isNR & config.is355nm & config.isTot;
+
+yLim_FR_RCS = config.yLim_FR_RCS;
+yLim_NR_RCS = config.yLim_NR_RCS;
+yLim_FR_DR = config.yLim_FR_DR;
+volDepol_532 = data.volDepol_532;
+RCS355FRColorRange = config.zLim_FR_RCS_355;
+RCS532FRColorRange = config.zLim_FR_RCS_532;
+RCS1064FRColorRange = config.zLim_FR_RCS_1064;
+RCS355NRColorRange = config.zLim_NR_RCS_355;
+RCS532NRColorRange = config.zLim_NR_RCS_532;
+
 if strcmpi(processInfo.visualizationMode, 'matlab')
     %% parameter initialize
     fileRCS355FR = fullfile(processInfo.pic_folder, campaignInfo.name, datestr(data.mTime(1), 'yyyy'), datestr(data.mTime(1), 'mm'), datestr(data.mTime(1), 'dd'), sprintf('%s_RCS_FR_355.png', rmext(taskInfo.dataFilename)));
@@ -23,19 +39,6 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     fileRCS532NR = fullfile(processInfo.pic_folder, campaignInfo.name, datestr(data.mTime(1), 'yyyy'), datestr(data.mTime(1), 'mm'), datestr(data.mTime(1), 'dd'), sprintf('%s_RCS_NR_532.png', rmext(taskInfo.dataFilename)));
     fileVolDepol355 = fullfile(processInfo.pic_folder, campaignInfo.name, datestr(data.mTime(1), 'yyyy'), datestr(data.mTime(1), 'mm'), datestr(data.mTime(1), 'dd'), sprintf('%s_VDR_355.png', rmext(taskInfo.dataFilename)));
     fileVolDepol532 = fullfile(processInfo.pic_folder, campaignInfo.name, datestr(data.mTime(1), 'yyyy'), datestr(data.mTime(1), 'mm'), datestr(data.mTime(1), 'dd'), sprintf('%s_VDR_532.png', rmext(taskInfo.dataFilename)));
-    flagChannel355 = config.isFR & config.is355nm & config.isTot;
-    flagChannel532 = config.isFR & config.is532nm & config.isTot;
-    flagChannel1064 = config.isFR & config.is1064nm & config.isTot;
-    flagChannel532NR = config.isNR & config.is532nm & config.isTot;
-    flagChannel355NR = config.isNR & config.is355nm & config.isTot;
-
-    yLim_FR = config.yLim_FR_RCS;
-    yLim_NR = config.yLim_NR_RCS;
-    RCS355FRColorRange = config.zLim_FR_RCS_355;
-    RCS532FRColorRange = config.zLim_FR_RCS_532;
-    RCS1064FRColorRange = config.zLim_FR_RCS_1064;
-    RCS355NRColorRange = config.zLim_NR_RCS_355;
-    RCS532NRColorRange = config.zLim_NR_RCS_532;
 
     %% visualization
     load('myjet_colormap.mat')   % load colormap
@@ -52,12 +55,12 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis(RCS355FRColorRange);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_RCS_FR);
+    ylim(yLim_FR_RCS);
     xlabel('UTC', 'FontSize', 7);
     ylabel('Height (m)', 'FontSize', 7);
     title(sprintf('Range-Corrected Signal at %snm Far-Range from %s at %s', '355', taskInfo.pollyVersion, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none', 'FontSize', 7);
     set(gca, 'Box', 'on', 'TickDir', 'out');
-    set(gca, 'ytick', linspace(yLim_RCS_FR(1), yLim_RCS_FR(2), 7), 'yminortick', 'on', 'FontSize', 7);
+    set(gca, 'ytick', linspace(yLim_FR_RCS(1), yLim_FR_RCS(2), 7), 'yminortick', 'on', 'FontSize', 7);
     set(gca, 'xtick', xtick, 'xticklabel', xtickstr);
     text(-0.04, -0.13, sprintf('%s', datestr(data.mTime(1), 'yyyy-mm-dd')), 'Units', 'Normal', 'FontSize', 7);
     text(0.90, -0.13, sprintf('Version %s', processInfo.programVersion), 'Units', 'Normal', 'FontSize', 7);
@@ -85,12 +88,12 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis(RCS532FRColorRange);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_RCS_FR);
+    ylim(yLim_FR_RCS);
     xlabel('UTC', 'FontSize', 7);
     ylabel('Height (m)', 'FontSize', 7);
     title(sprintf('Range-Corrected Signal at %snm Far-Range from %s at %s', '532', taskInfo.pollyVersion, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none', 'FontSize', 7);
     set(gca, 'Box', 'on', 'TickDir', 'out');
-    set(gca, 'ytick', linspace(yLim_RCS_FR(1), yLim_RCS_FR(2), 7), 'yminortick', 'on', 'FontSize', 7);
+    set(gca, 'ytick', linspace(yLim_FR_RCS(1), yLim_FR_RCS(2), 7), 'yminortick', 'on', 'FontSize', 7);
     set(gca, 'xtick', xtick, 'xticklabel', xtickstr);
     text(-0.04, -0.13, sprintf('%s', datestr(data.mTime(1), 'yyyy-mm-dd')), 'Units', 'Normal', 'FontSize', 7);
     text(0.90, -0.13, sprintf('Version %s', processInfo.programVersion), 'Units', 'Normal', 'FontSize', 7);
@@ -118,12 +121,12 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis(RCS1064FRColorRange);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_RCS_FR);
+    ylim(yLim_FR_RCS);
     xlabel('UTC', 'FontSize', 7);
     ylabel('Height (m)', 'FontSize', 7);
     title(sprintf('Range-Corrected Signal at %snm Far-Range from %s at %s', '1064', taskInfo.pollyVersion, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none', 'FontSize', 7);
     set(gca, 'Box', 'on', 'TickDir', 'out');
-    set(gca, 'ytick', linspace(yLim_RCS_FR(1), yLim_RCS_FR(2), 7), 'yminortick', 'on', 'FontSize', 7);
+    set(gca, 'ytick', linspace(yLim_FR_RCS(1), yLim_FR_RCS(2), 7), 'yminortick', 'on', 'FontSize', 7);
     set(gca, 'xtick', xtick, 'xticklabel', xtickstr);
     text(-0.04, -0.13, sprintf('%s', datestr(data.mTime(1), 'yyyy-mm-dd')), 'Units', 'Normal', 'FontSize', 7);
     text(0.90, -0.13, sprintf('Version %s', processInfo.programVersion), 'Units', 'Normal', 'FontSize', 7);
@@ -151,7 +154,7 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis(RCS355NRColorRange);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_RCS_NR);
+    ylim(yLim_NR_RCS);
     xlabel('UTC', 'FontSize', 7);
     ylabel('Height (m)', 'FontSize', 7);
     title(sprintf('Range-Corrected Signal at %snm Near-Range from %s at %s', '355', taskInfo.pollyVersion, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none', 'FontSize', 7);
@@ -184,7 +187,7 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis(RCS532NRColorRange);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_RCS_NR);
+    ylim(yLim_NR_RCS);
     xlabel('UTC', 'FontSize', 7);
     ylabel('Height (m)', 'FontSize', 7);
     title(sprintf('Range-Corrected Signal at %snm Near-Range from %s at %s', '532', taskInfo.pollyVersion, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none', 'FontSize', 7);
@@ -217,12 +220,12 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis([0, 0.4]);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_RCS_FR);
+    ylim(yLim_FR_DR);
     xlabel('UTC', 'FontSize', 7);
     ylabel('Height (m)', 'FontSize', 7);
     title(sprintf('Volume Depolarization Ratio at %snm from %s at %s', '532', taskInfo.pollyVersion, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none', 'FontSize', 7);
     set(gca, 'Box', 'on', 'TickDir', 'out');
-    set(gca, 'ytick', linspace(yLim_RCS_FR(1), yLim_RCS_FR(2), 7), 'yminortick', 'on');
+    set(gca, 'ytick', linspace(yLim_FR_DR(1), yLim_FR_DR(2), 7), 'yminortick', 'on');
     set(gca, 'xtick', xtick, 'xticklabel', xtickstr);
     text(-0.04, -0.13, sprintf('%s', datestr(data.mTime(1), 'yyyy-mm-dd')), 'Units', 'Normal', 'FontSize', 7);
     text(0.90, -0.13, sprintf('Version %s', processInfo.programVersion), 'Units', 'Normal', 'FontSize', 7);
@@ -250,12 +253,12 @@ if strcmpi(processInfo.visualizationMode, 'matlab')
     set(p1, 'EdgeColor', 'none');
     caxis([0, 0.4]);
     xlim([data.mTime(1), data.mTime(end)]);
-    ylim(yLim_RCS_FR);
+    ylim(yLim_FR_DR);
     xlabel('UTC', 'FontSize', 7);
     ylabel('Height (m)', 'FontSize', 7);
     title(sprintf('Volume Depolarization Ratio at %snm from %s at %s', '355', taskInfo.pollyVersion, campaignInfo.location), 'fontweight', 'bold', 'interpreter', 'none', 'FontSize', 7);
     set(gca, 'Box', 'on', 'TickDir', 'out');
-    set(gca, 'ytick', linspace(yLim_RCS_FR(1), yLim_RCS_FR(2), 7), 'yminortick', 'on');
+    set(gca, 'ytick', linspace(yLim_FR_DR(1), yLim_FR_DR(2), 7), 'yminortick', 'on');
     set(gca, 'xtick', xtick, 'xticklabel', xtickstr);
     text(-0.04, -0.13, sprintf('%s', datestr(data.mTime(1), 'yyyy-mm-dd')), 'Units', 'Normal', 'FontSize', 7);
     text(0.90, -0.13, sprintf('Version %s', processInfo.programVersion), 'Units', 'Normal', 'FontSize', 7);
@@ -287,11 +290,6 @@ elseif strcmpi(processInfo.visualizationMode, 'python')
 
     %% preparing the data
     [xtick, xtickstr] = timelabellayout(data.mTime, 'HH:MM');
-    flagChannel355 = config.isFR & config.is355nm & config.isTot;
-    flagChannel532 = config.isFR & config.is532nm & config.isTot;
-    flagChannel1064 = config.isFR & config.is1064nm & config.isTot;
-    flagChannel532NR = config.isNR & config.is532nm & config.isTot;
-    flagChannel355NR = config.isNR & config.is355nm & config.isTot;
     mTime = data.mTime;
     height = data.height;
     figDPI = processInfo.figDPI;
@@ -339,18 +337,9 @@ elseif strcmpi(processInfo.visualizationMode, 'python')
         RCS_NR_532 = NaN(size(data.signal, 2), size(data.signal, 3));
     end
 
-    yLim_FR = config.yLim_FR_RCS;
-    yLim_NR = config.yLim_NR_RCS;
-    volDepol_532 = data.volDepol_532;
-    RCS355FRColorRange = config.zLim_FR_RCS_355;
-    RCS532FRColorRange = config.zLim_FR_RCS_532;
-    RCS1064FRColorRange = config.zLim_FR_RCS_1064;
-    RCS355NRColorRange = config.zLim_NR_RCS_355;
-    RCS532NRColorRange = config.zLim_NR_RCS_355;
-
     %% display rcs 
     tmpFile = fullfile(tmpFolder, [basename(tempname), '.mat']);
-    save(tmpFile, 'figDPI', 'mTime', 'height', 'depCalMask', 'fogMask', 'yLim_FR', 'yLim_NR', 'RCS_FR_355', 'RCS_FR_532', 'RCS_FR_1064', 'RCS_NR_355', 'RCS_NR_532', 'volDepol_532', 'processInfo', 'campaignInfo', 'taskInfo', 'xtick', 'xtickstr', 'RCS355FRColorRange', 'RCS532FRColorRange', 'RCS1064FRColorRange', 'RCS355NRColorRange', 'RCS532NRColorRange', '-v6');
+    save(tmpFile, 'figDPI', 'mTime', 'height', 'depCalMask', 'fogMask', 'yLim_FR_RCS', 'yLim_NR_RCS', 'yLim_FR_DR', 'RCS_FR_355', 'RCS_FR_532', 'RCS_FR_1064', 'RCS_NR_355', 'RCS_NR_532', 'volDepol_532', 'processInfo', 'campaignInfo', 'taskInfo', 'xtick', 'xtickstr', 'RCS355FRColorRange', 'RCS532FRColorRange', 'RCS1064FRColorRange', 'RCS355NRColorRange', 'RCS532NRColorRange', '-v6');
     flag = system(sprintf('%s %s %s %s', fullfile(processInfo.pyBinDir, 'python'), fullfile(pyFolder, 'pollyxt_ift_display_rcs.py'), tmpFile, saveFolder));
     if flag ~= 0
         warning('Error in executing %s', 'pollyxt_ift_display_rcs.py');

--- a/lib/pollyxt_ift_func_lib/pollyxt_ift_display_rcs.py
+++ b/lib/pollyxt_ift_func_lib/pollyxt_ift_display_rcs.py
@@ -118,8 +118,9 @@ def pollyxt_ift_display_rcs(tmpFile, saveFolder):
         version = mat['processInfo']['programVersion'][0][0][0]
         fontname = mat['processInfo']['fontname'][0][0][0]
         dataFilename = mat['taskInfo']['dataFilename'][0][0][0]
-        yLim_FR = mat['yLim_FR'][:][0]
-        yLim_NR = mat['yLim_NR'][:][0]
+        yLim_FR_RCS = mat['yLim_FR_RCS'][:][0]
+        yLim_NR_RCS = mat['yLim_NR_RCS'][:][0]
+        yLim_FR_DR = mat['yLim_FR_DR'][:][0]
         RCS355FRColorRange = mat['RCS355FRColorRange'][:][0]
         RCS532FRColorRange = mat['RCS532FRColorRange'][:][0]
         RCS1064FRColorRange = mat['RCS1064FRColorRange'][:][0]
@@ -161,7 +162,7 @@ def pollyxt_ift_display_rcs(tmpFile, saveFolder):
 
     ax.yaxis.set_major_locator(MultipleLocator(2500))
     ax.yaxis.set_minor_locator(MultipleLocator(500))
-    ax.set_ylim([yLim_FR[0], yLim_FR[1]])
+    ax.set_ylim([yLim_FR_RCS[0], yLim_FR_RCS[1]])
     ax.set_xticks(xtick.tolist())
     ax.set_xticklabels(celltolist(xticklabel))
     ax.tick_params(axis='both', which='major', labelsize=15,
@@ -207,7 +208,7 @@ def pollyxt_ift_display_rcs(tmpFile, saveFolder):
 
     ax.yaxis.set_major_locator(MultipleLocator(2500))
     ax.yaxis.set_minor_locator(MultipleLocator(500))
-    ax.set_ylim([yLim_FR[0], yLim_FR[1]])
+    ax.set_ylim([yLim_FR_RCS[0], yLim_FR_RCS[1]])
     ax.set_xticks(xtick.tolist())
     ax.set_xticklabels(celltolist(xticklabel))
     ax.tick_params(axis='both', which='major', labelsize=15,
@@ -253,7 +254,7 @@ def pollyxt_ift_display_rcs(tmpFile, saveFolder):
 
     ax.yaxis.set_major_locator(MultipleLocator(2500))
     ax.yaxis.set_minor_locator(MultipleLocator(500))
-    ax.set_ylim([yLim_FR[0], yLim_FR[1]])
+    ax.set_ylim([yLim_FR_RCS[0], yLim_FR_RCS[1]])
     ax.set_xticks(xtick.tolist())
     ax.set_xticklabels(celltolist(xticklabel))
     ax.tick_params(axis='both', which='major', labelsize=15,
@@ -301,7 +302,7 @@ def pollyxt_ift_display_rcs(tmpFile, saveFolder):
 
     ax.yaxis.set_major_locator(MultipleLocator(1000))
     ax.yaxis.set_minor_locator(MultipleLocator(200))
-    ax.set_ylim([yLim_NR[0], yLim_NR[1]])
+    ax.set_ylim([yLim_NR_RCS[0], yLim_NR_RCS[1]])
     ax.set_xticks(xtick.tolist())
     ax.set_xticklabels(celltolist(xticklabel))
     ax.tick_params(axis='both', which='major', labelsize=15,
@@ -347,7 +348,7 @@ def pollyxt_ift_display_rcs(tmpFile, saveFolder):
 
     ax.yaxis.set_major_locator(MultipleLocator(1000))
     ax.yaxis.set_minor_locator(MultipleLocator(200))
-    ax.set_ylim([yLim_NR[0], yLim_NR[1]])
+    ax.set_ylim([yLim_NR_RCS[0], yLim_NR_RCS[1]])
     ax.set_xticks(xtick.tolist())
     ax.set_xticklabels(celltolist(xticklabel))
     ax.tick_params(axis='both', which='major', labelsize=15,
@@ -393,7 +394,7 @@ def pollyxt_ift_display_rcs(tmpFile, saveFolder):
 
     ax.yaxis.set_major_locator(MultipleLocator(2500))
     ax.yaxis.set_minor_locator(MultipleLocator(500))
-    ax.set_ylim([yLim_FR[0], yLim_FR[1]])
+    ax.set_ylim([yLim_FR_DR[0], yLim_FR_DR[1]])
     ax.set_xticks(xtick.tolist())
     ax.set_xticklabels(celltolist(xticklabel))
     ax.tick_params(axis='both', which='major', labelsize=15,


### PR DESCRIPTION
Add separated settings for the y-axis of volumn depolarization ratio colorplot. Before this commit,
this settings is binded with range-corrected signal.

Resove Issue #24 .