### PR TITLE
corrected filename ending

### DIFF
--- a/lib/io/pollySaveNRAttnBeta.m
+++ b/lib/io/pollySaveNRAttnBeta.m
@@ -16,7 +16,7 @@ missing_value = -999;
 
 global PicassoConfig CampaignConfig PollyDataInfo PollyConfig
 
-ncfile = fullfile(PicassoConfig.results_folder, CampaignConfig.name, datestr(data.mTime(1), 'yyyy'), datestr(data.mTime(1), 'mm'), datestr(data.mTime(1), 'dd'), sprintf('%s_NR_att_bsc_2.nc', rmext(PollyDataInfo.pollyDataFile)));
+ncfile = fullfile(PicassoConfig.results_folder, CampaignConfig.name, datestr(data.mTime(1), 'yyyy'), datestr(data.mTime(1), 'mm'), datestr(data.mTime(1), 'dd'), sprintf('%s_NR_att_bsc.nc', rmext(PollyDataInfo.pollyDataFile)));
 
 mode = netcdf.getConstant('NETCDF4');
 mode = bitor(mode, netcdf.getConstant('CLASSIC_MODEL'));


### PR DESCRIPTION
the near range files were still named '*NR_att_bsc_2.nc'. changed it to '*NR_att_bsc.nc'. when I created the routine for the near-range SNR I changed the name for testing purposes. somehow it was not changed back.