### PR TITLE
check mTime for correct timestamp within nc-file

### DIFF
--- a/lib/io/readPollyRawData.m
+++ b/lib/io/readPollyRawData.m
@@ -116,6 +116,8 @@ catch
     return;
 end
 
+
+
 if p.Results.flagDeleteData
     delete(file);
 end
@@ -143,21 +145,26 @@ if p.Results.flagFilterFalseMShots
             depCalAng = depCalAng(~ flagFalseShots);
         end
     end
-
 elseif p.Results.flagCorrectFalseMShots
-    mShots(:, flagFalseShots) = mShotsPer30s;
-    mTimeStart = floor(pollyParseFiletime(file, p.Results.dataFileFormat) / ...
-                       datenum(0,1,0,0,0,30)) * datenum(0,1,0,0,0,30);
-    [thisYear, thisMonth, thisDay, thisHour, thisMinute, thisSecond] = ...
-                       datevec(mTimeStart);
-    mTime(1, :) = thisYear * 1e4 + thisMonth * 1e2 + thisDay;
-    mTime(2, :) = thisHour * 3600 + ...
-                 thisMinute * 60 + ...
-                 thisSecond + 30 .* (0:(size(mTime, 2) - 1));
-
-    mTime = ncread(file, 'measurement_time');
+    % check measurement time
+    if mTime(1,:) == 19700101
+        warning('Measurement time will be read from filename (not from within nc-file).\n%s\n', file);
+        
+        mShots(:, flagFalseShots) = mShotsPer30s;
+        mTimeStart = floor(pollyParseFiletime(file, p.Results.dataFileFormat) / ...
+                           datenum(0,1,0,0,0,30)) * datenum(0,1,0,0,0,30);
+        [thisYear, thisMonth, thisDay, thisHour, thisMinute, thisSecond] = ...
+                           datevec(mTimeStart);
+        mTime(1, :) = thisYear * 1e4 + thisMonth * 1e2 + thisDay;
+        mTime(2, :) = thisHour * 3600 + ...
+                     thisMinute * 60 + ...
+                     thisSecond + 30 .* (0:(size(mTime, 2) - 1));
+    else
+        fprintf('Measurement time will be read from within nc-file.\n%s\n', file);
+        mTime = ncread(file, 'measurement_time');
+    end
 end
-
+disp(mTime)
 data.filenameStartTime = pollyParseFiletime(file, p.Results.dataFileFormat);
 data.zenithAng = zenithAng;
 data.hRes = hRes;

--- a/lib/io/readPollyRawData.m
+++ b/lib/io/readPollyRawData.m
@@ -154,6 +154,8 @@ elseif p.Results.flagCorrectFalseMShots
     mTime(2, :) = thisHour * 3600 + ...
                  thisMinute * 60 + ...
                  thisSecond + 30 .* (0:(size(mTime, 2) - 1));
+
+    mTime = ncread(file, 'measurement_time');
 end
 
 data.filenameStartTime = pollyParseFiletime(file, p.Results.dataFileFormat);


### PR DESCRIPTION
Sorry for confusions... this pull request is for this branch to dev (not to master).
From now on the measurementtime in "readPollyRawData.m" will be checked first, before written to the variable "mTime". If the timestamp from within the nc-file starts with 19700101, the measurementtime will be taken from the nc-filename. Otherwise the measurementtime will be taken directly from within the nc-file and written to the variable "mTime".