### PR TITLE
Use of measurement time instead of measurement shots to avoid trigger…

### DIFF
--- a/lib/preprocess/pollyPreprocess.m
+++ b/lib/preprocess/pollyPreprocess.m
@@ -218,9 +218,9 @@ end
 
 %% Re-sample the temporal grid to defined temporal grid with interval of deltaT
 mShotsPerPrf = p.Results.deltaT * data.repRate;
-nInt = round(mShotsPerPrf / nanmean(data.mShots(1, :), 2));   % number of profiles to be
-                                                              % integrated. Usually, 600
-                                                              % shots per 30 s
+nInt = round(p.Results.deltaT / (nanmean(diff(data.mTime))*24*3600));   % number of profiles to be
+                                                                        % integrated. Usually, 600
+                                                                        % shots per 30 s
 
 if nInt > 1
     % if shots of single profile is less than mShotsPerPrf


### PR DESCRIPTION
The PollyPreprocess.m function was modified to consider the measurement time instead of the measurement shots to avoid trigger issues in the resampling of the data