### PR TITLE
Add reader for cloudnet ecmwf profile data

### DIFF
--- a/lib/io/loadMeteor.m
+++ b/lib/io/loadMeteor.m
@@ -13,11 +13,11 @@ function [temp, pres, relh, wins, wind, meteorAttri] = loadMeteor(mTime, asl, va
 % KEYWORDS:
 %    meteorDataSource: str
 %        meteorological data type.
-%        e.g., 'gdas1'(default), 'standard_atmosphere', 'websonde', 'radiosonde'
+%        e.g., 'gdas1'(default), 'standard_atmosphere', 'websonde', 'radiosonde', 'nc_cloudnet'
 %    gdas1Site: str
 %        the GDAS1 site for the current campaign.
 %    gdas1_folder: str
-%        the main folder of the GDAS1 profiles.
+%        the main folder of the GDAS1 profiles (or the cloudnet profiles).
 %    radiosondeSitenum: integer
 %        site number, which can be found in 
 %        doc/radiosonde-station-list.txt.

--- a/lib/io/readMETnccloudnet.m
+++ b/lib/io/readMETnccloudnet.m
@@ -1,0 +1,124 @@
+function [alt, temp, pres, relh, wins, wind, fname] = readMETnccloudnet(tRange, site, folder, varargin)
+% readMETnccloudnet read the cloudnet ecmwf netcdf file
+%
+% EXAMPLE:
+%    [alt, temp, pres, relh] = readMETnccloudnet(tRange, site, folder)
+%
+% INPUTS:
+%    tRange: 2-element array
+%        search range. 
+%    site: char
+%        the location for gdas1. Our server will automatically produce the 
+%        gdas1 products for all our pollynet location. You can find it in 
+%        /lacroshome/cloudnet/data/model/gdas1
+%
+% KEYWORDS:
+%    isUseLatestGDAS: logical
+%        whether to search the latest available GDAS profile (default: false).
+%
+% OUTPUTS:
+%    alt: array
+%        altitute (above ground) for each range bin. [m]
+%    temp: array
+%        temperature for each range bin. If no valid data, NaN will be 
+%        filled. [C]
+%    pres: array
+%        pressure for each range bin. If no valid data, NaN will be filled. 
+%        [hPa]
+%    rh: array
+%        relative humidity for each range bin. If no valid data, NaN will be 
+%        filled. [%]
+%    wins: array
+%        wind speed [m/s]
+%    wind: array
+%        wind direction. [degree]
+%    fname: char
+%        filename (for legacy reasons the name is not changed). 
+%
+% HISTORY:
+%    - 2023-05-13.:First implementation by martin-rdz
+%
+% .. Authors: - radenz@tropos.de
+
+p = inputParser;
+p.KeepUnmatched = true;
+
+addRequired(p, 'tRange', @isnumeric);
+addRequired(p, 'site', @ischar);
+addRequired(p, 'folder', @ischar);
+
+parse(p, tRange, site, folder, varargin{:});
+
+midTime = mean(tRange);
+
+[thisyear, thismonth, thisday, thishour, ~, ~] = ...
+            datevec(round(midTime / datenum(0, 1, 0, 3, 0, 0)) * ...
+            datenum(0, 1, 0, 3, 0, 0));
+% /oceanethome/model/ecmwf/profiles/ecmwf/2023/20230512_neumayer_ecmwf.nc
+fname = fullfile(folder, sprintf('%04d', thisyear), ...
+            sprintf('%04d%02d%02d_%s_ecmwf.nc', ...
+            thisyear, thismonth, thisday, site));
+
+disp(fname);
+%disp(tRange);
+
+% Open the netCDF file
+ncid = netcdf.open(fname, 'NOWRITE');
+
+
+% Get information about the netCDF file
+nc_info = ncinfo(fname);
+% Extract the variable names
+var_names = {nc_info.Variables.Name};
+% Display the variable names
+%disp(var_names);
+
+% Get the variable ID for the time variable and the variable of interest
+%time_varid = netcdf.inqVarID(ncid, 'time');
+%data_varid = netcdf.inqVarID(ncid, 'variable_name');
+
+% Read in the time variable and the variable of interest
+time = ncread(fname, 'time');
+[~, ~, ~, hour, minute, second] = datevec(midTime);
+hour_fraction = hour + minute/60 + second/3600;
+
+disp(hour_fraction);
+
+% Find the index of the time value closest to the specified time
+[~, index] = min(abs(time - hour_fraction));
+
+height = ncread(fname, 'height');
+alt = height(:, index);
+
+% Extract the corresponding data
+data = ncread(fname, 'pressure');
+pres = data(:, index) ./ 100.;
+
+data = ncread(fname, 'temperature');
+temp = data(:, index) - 273.15;
+
+data = ncread(fname, 'rh');
+relh = data(:, index) .* 100;
+
+data = ncread(fname, 'uwind');
+uwd = data(:, index);
+
+data = ncread(fname, 'vwind');
+vwd = data(:, index);
+
+wins = sqrt(uwd.^2 + vwd.^2);
+wind = atan2(vwd,uwd)*(180/pi);
+
+% Close the netCDF file
+netcdf.close(ncid);
+
+%#[pres, alt, temp, relh, wind, wins] = ceilo_bsc_ModelSonde(gdas1file);
+
+%pres    = NaN;
+%alt     = NaN;
+%temp    = NaN;
+%relh    = NaN;
+%wind    = NaN;
+%wins    = NaN;
+
+end

--- a/lib/io/readMeteor.m
+++ b/lib/io/readMeteor.m
@@ -171,6 +171,24 @@ case 'radiosonde'
         end
     end
 
+case 'nc_cloudnet'
+    [alt, temp, pres, relh, wins, wind, gdas1File] = readMETnccloudnet(measTime, ...
+        p.Results.gdas1Site, p.Results.gdas1_folder, ...
+        'isUseLatestGDAS', p.Results.isUseLatestGDAS);
+
+    if isempty(alt)
+        alt = [];
+        temp = [];
+        pres = [];
+        relh = [];
+        wins = [];
+        wind = [];
+    else
+        attri.dataSource = p.Results.meteorDataSource;
+        attri.URL = gdas1File;
+        attri.datetime = measTime;
+    end
+
 otherwise
     error('Unknown meteorological data source.\n%s\n', ...
           p.Results.meteorDataSource)


### PR DESCRIPTION
The cloudnet datacenter provides profile extracts from ECMWF IFS for stations on the extraction list (https://cloudnetpy.readthedocs.io/en/latest/quickstart.html#model-data).
A daily netcdf file contains hourly profiles with 136 height levels (https://cloudnetpy.readthedocs.io/en/latest/fileformat.html#model-file).
This data should be superior to the GDAS files.

The datasource can be either configured in the config files or in matlab directly (hinting to https://github.com/PollyNET/picasso-nb-interface ;) )
```
PollyConfig.meteorDataSource = 'nc_cloudnet';
PicassoConfig.gdas1_folder = '/oceanethome/model/ecmwf/profiles/ecmwf/';
```

Example for arielle at Neumayer:
![grafik](https://github.com/PollyNET/Pollynet_Processing_Chain/assets/31452472/8b70acb4-fa90-4adf-ab60-6c5b895a0429)

Open issue: The relative humidity is provided above water and ice depending on temperature.
I am not sure what the effect is on downstream data analysis. Quoting from the ncdump
```
        float rh(time, level) ;
                rh:_FillValue = -999.9f ;
                rh:long_name = "Relative humidity" ;
                rh:units = "1" ;
                rh:missing_value = -999.9f ;
                rh:comment = "With respect to liquid above 0 degrees C and with respect to ice below 0 degrees C. 
                                         Calculated using Goff-Gratch formula." ;
                rh:standard_name = "relative_humidity" ;
```
However, also the specific humidity is available in the file, so we could calculate on our own.




