### PR TITLE
added option to read IWV values from HATPRO-MWR cloudnet products

### DIFF
--- a/lib/io/readIWV.m
+++ b/lib/io/readIWV.m
@@ -51,6 +51,7 @@ function [IWV, globalAttri] = readIWV(instrument, clFreTime, varargin)
 %    - 2018-12-26: First Edition by Zhenping
 %    - 2019-05-19: Fix the bug of returning empty IWV when more than 2 MWR files were found.
 %    - 2023-07-12: Addded MWR_cloudnet source
+%    - 2023-07-13: Added correct location subdir for MWR_cloudnet
 %
 % .. Authors: - zhenping@tropos.de, klamt@tropos.de
 
@@ -125,8 +126,23 @@ case 'mwr_cloudnet'
 %         %sprintf('*_mwr00_l2_prw_v00_%s*.nc', ...
 %         sprintf('*%s_hatpro_proc*.nc', ...
 %            datestr(clFreTime(1), 'yyyymmdd'))));
+    
+    % looking for the correct location subfolder:
+    % Get a list of folders in the MWRFolder directory
+    folders = dir(p.Results.MWRFolder);
+    folders = folders([folders.isdir]);  % Filter out non-folders
+    
+    % Find the subdirectory with a case-insensitive search
+    locationsubDir = [];
+    for i = 1:numel(folders)
+        if strcmpi(folders(i).name, p.Results.MWRSite)
+            locationsubDir = folders(i).name;
+            break;
+        end
+    end
+   
      mwrResFilename = fullfile(p.Results.MWRFolder, ...
-         sprintf('*'), ... % location directory
+         sprintf('%s', locationsubDir), ... % location directory from p.Results.MWRSite
          sprintf('%s', datestr(clFreTime(1), 'yyyy')), ...
          sprintf('%s', datestr(clFreTime(1), 'mm')), ...
          sprintf('%s', datestr(clFreTime(1), 'dd')), ...

--- a/lib/io/readMWR_cloudnet.m
+++ b/lib/io/readMWR_cloudnet.m
@@ -1,0 +1,66 @@
+function [tIWV, IWV, IWVAttri] = readMWR_cloudnet(files)
+% READMWR read integrated water vapor from the microwave radiometer outputs.
+%
+% USAGE:
+%    [tIWV, IWV, IWVAttri] = readMWR(files)
+%
+% INPUTS:
+%    files: char | cell
+%        absolute paths of the netcdf files for saving the IWV results from 
+%        HATPRO. Generally, you can find the data on rsd2 server: 
+%        '/data/level1b/cloudnetpy/products/'. Otherwise those data can be
+%        accessed via the cloudnet page from the fmi institution, e.g.:
+%        'https://cloudnet.fmi.fi/search/data?site=mindelo&dateFrom=2023-03-27&dateTo=2023-03-27&product=mwr'
+%
+% OUTPUTS:
+%    IWV: array
+%        intergrated water vapor. [kg*m^{-2}] 
+%    tIWV: array
+%        time for each bin. [datenum]
+%    IWVAttri: struct
+%        instrument_pid: char
+%            unique instrument_pid given by the fmi
+%        source: char
+%            data source or instrument.
+%        site: char
+%            site
+%
+% HISTORY:
+%    - 2023-07-12: First Edition by Andi Klamt
+%
+% .. Authors: - klamt@tropos.de
+
+tIWV = [];
+IWV = [];
+IWVAttri = struct();
+IWVAttri.instrument_pid = '';
+IWVAttri.source = '';
+IWVAttri.site = '';
+
+if ischar(files)
+    files = {files};   % convert char array to cell
+end
+
+for iFile = 1:length(files)
+
+    thisFile = files{iFile};
+
+    if exist(thisFile, 'file') ~= 2
+        warning('HATPRO file does not exist.\n%s\n', thisFile);
+        continue;
+    end
+
+    %% read data
+    thisIWV = ncread(thisFile, 'iwv');
+    thisTSec = ncread(thisFile, 'time');
+    thistIWV = unix_timestamp_2_datenum(thisTSec);
+    IWVAttri.instrument_pid = ncreadatt(thisFile, '/', 'instrument_pid');
+    IWVAttri.source = ncreadatt(thisFile, '/', 'source');
+    IWVAttri.site = ncreadatt(thisFile, '/', 'location');
+
+    %% append data
+    tIWV = cat(1, tIWV, thistIWV);
+    IWV = cat(1, IWV, thisIWV);
+end
+
+end


### PR DESCRIPTION
This new function adds the option to use IWV cloudnet products from HATPRO-MWR.
To use this new function, one has to change the following key/values in the polly_global_config.json file:

```"IWV_instrument": "MWR_cloudnet",```
```"MWRFolder": "/data/level1b/cloudnetpy/products",```

This pull request refers to issue https://github.com/PollyNET/Pollynet_Processing_Chain/issues/152