### PR TITLE
Bugfixes of wrong assiged aerosol backscatter in in-complete overlap zone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ todo_filelist
 test
 netcdf4
 log
+analysis
 done_filelist
 
 # Sphinx build

--- a/lib/interface/picassoProcV3.m
+++ b/lib/interface/picassoProcV3.m
@@ -3327,7 +3327,7 @@ for iGrp = 1:size(clFreGrps, 1)
 
             % optical thickness (OT)
             aExt355 = aerExt355_klett(iGrp, :);
-            aExt355(1:hIndBase) = aerExt355_klett(hIndBase);
+            aExt355(1:hIndBase) = aerExt355_klett(iGrp, hIndBase);
             aBsc355 = aerBsc355_klett(iGrp, :);
             aOT355 = nancumsum(aExt355 .* [data.distance0(1), diff(data.distance0)]);
             mOT355 = nancumsum(mExt355 .* [data.distance0(1), diff(data.distance0)]);
@@ -3366,7 +3366,7 @@ for iGrp = 1:size(clFreGrps, 1)
 
             % optical thickness (OT)
             aExt532 = aerExt532_klett(iGrp, :);
-            aExt532(1:hIndBase) = aerExt532_klett(hIndBase);
+            aExt532(1:hIndBase) = aerExt532_klett(iGrp, hIndBase);
             aBsc532 = aerBsc532_klett(iGrp, :);
             aOT532 = nancumsum(aExt532 .* [data.distance0(1), diff(data.distance0)]);
             mOT532 = nancumsum(mExt532 .* [data.distance0(1), diff(data.distance0)]);
@@ -3405,7 +3405,7 @@ for iGrp = 1:size(clFreGrps, 1)
 
             % optical thickness (OT)
             aExt1064 = aerExt1064_klett(iGrp, :);
-            aExt1064(1:hIndBase) = aerExt1064_klett(hIndBase);
+            aExt1064(1:hIndBase) = aerExt1064_klett(iGrp, hIndBase);
             aBsc1064 = aerBsc1064_klett(iGrp, :);
             aOT1064 = nancumsum(aExt1064 .* [data.distance0(1), diff(data.distance0)]);
             mOT1064 = nancumsum(mExt1064 .* [data.distance0(1), diff(data.distance0)]);
@@ -3632,7 +3632,7 @@ for iGrp = 1:size(clFreGrps, 1)
 
             % optical thickness (OT)
             aExt355 = aerExt355_aeronet(iGrp, :);
-            aExt355(1:hIndBase) = aerExt355_aeronet(hIndBase);
+            aExt355(1:hIndBase) = aerExt355_aeronet(iGrp, hIndBase);
             aBsc355 = aerBsc355_aeronet(iGrp, :);
             aOT355 = nancumsum(aExt355 .* [data.distance0(1), diff(data.distance0)]);
             mOT355 = nancumsum(mExt355 .* [data.distance0(1), diff(data.distance0)]);
@@ -3671,7 +3671,7 @@ for iGrp = 1:size(clFreGrps, 1)
 
             % optical thickness (OT)
             aExt532 = aerExt532_aeronet(iGrp, :);
-            aExt532(1:hIndBase) = aerExt532_aeronet(hIndBase);
+            aExt532(1:hIndBase) = aerExt532_aeronet(iGrp, hIndBase);
             aBsc532 = aerBsc532_aeronet(iGrp, :);
             aOT532 = nancumsum(aExt532 .* [data.distance0(1), diff(data.distance0)]);
             mOT532 = nancumsum(mExt532 .* [data.distance0(1), diff(data.distance0)]);
@@ -3710,7 +3710,7 @@ for iGrp = 1:size(clFreGrps, 1)
 
             % optical thickness (OT)
             aExt1064 = aerExt1064_aeronet(iGrp, :);
-            aExt1064(1:hIndBase) = aerExt1064_aeronet(hIndBase);
+            aExt1064(1:hIndBase) = aerExt1064_aeronet(iGrp, hIndBase);
             aBsc1064 = aerBsc1064_aeronet(iGrp, :);
             aOT1064 = nancumsum(aExt1064 .* [data.distance0(1), diff(data.distance0)]);
             mOT1064 = nancumsum(mExt1064 .* [data.distance0(1), diff(data.distance0)]);


### PR DESCRIPTION
bugfixes: wrong assigned value
Bug Description
---------------

As noticed by Adi, wrong aerosol backscatter values were assigned in in-complete overlap zone. See code [here](https://github.com/PollyNET/Pollynet_Processing_Chain/blob/b4f0cb38613f1059cf0e9cb2b60211e62e59bdb4/lib/interface/picassoProcV3.m#L3328C1-L3333C86) and code snippet below:

```matlab
    aExt355 = aerExt355_klett(iGrp, :);
    aExt355(1:hIndBase) = aerExt355_klett(hIndBase);
```

Here, `aerExt355_klett` is 2-D matrix (height x time). This copy operation will only fill the aerosol backscatter with values from the first profile. This bug can introduce some error in the lidar calibration constant, depending on the aerosol variations over time.

Bug fixes
---------

I have corrected the code as below,

```matlab
    aExt355 = aerExt355_klett(iGrp, :);
    aExt355(1:hIndBase) = aerExt355_klett(iGrp, hIndBase);
```

This fix has been applied all over the main function of `picassoProcV3`.