### PR TITLE
Win24h updated

### DIFF
--- a/lib/config/polly_global_config.json
+++ b/lib/config/polly_global_config.json
@@ -271,6 +271,8 @@
     "comment": "",
 
     "logbookFile": "",
+    "logbookPath": "",
+    "logbookFileName": "",
     "radiosondeFolder": "",
     "calibrationDB": "polly_calibration.db",
     "imgFormat": "png",

--- a/lib/config/template_polly_global_config.json
+++ b/lib/config/template_polly_global_config.json
@@ -20,6 +20,7 @@
 
     "dataFileFormat": "(?<year>\\d{4})_(?<month>\\d{2})_(?<day>\\d{2})_\\w*_(?<hour>\\d{2})_(?<minute>\\d{2})_(?<second>\\d{2})\\w*.nc",
     "gdas1Site": "",
+    "meteorDataSource": "gdas1",
     "meteo_folder": "",
     "AERONETSite": "",
 
@@ -151,6 +152,11 @@
     "smoothWin_klett_1064": 21,
     "smoothWin_klett_NR_355": 21,
     "smoothWin_klett_NR_532": 21,
+    "smoothWin_raman_355": 99,
+    "smoothWin_raman_532": 99,
+    "smoothWin_raman_1064": 99,
+    "smoothWin_raman_NR_355": 25,
+    "smoothWin_raman_NR_532": 25,
     "maxIterConstrainFernald": 20,
     "minLRConstrainFernald": 1,
     "maxLRConstrainFernald": 150,
@@ -167,11 +173,6 @@
     "min_RR_RefSNR1058": 0,
     "angstrexp": 0.9,
     "angstrexp_NR": 0.9,
-    "smoothWin_raman_355": 61,
-    "smoothWin_raman_532": 61,
-    "smoothWin_raman_1064": 61,
-    "smoothWin_raman_NR_355": 31,
-    "smoothWin_raman_NR_532": 31,
     "LCMeanWindow": 50,
     "LCMeanMinIndx": 70,
     "LCMeanMaxIndx": 1000,
@@ -270,9 +271,11 @@
     "comment": "",
 
     "logbookFile": "",
+    "logbookPath": "",
+    "logbookFileName": "",
     "radiosondeFolder": "",
     "calibrationDB": "polly_calibration.db",
     "imgFormat": "png",
     "partnerLabel": "",
-    "prodSaveList": ["overlap", "aerProfFR", "aerProfNR", "aerProfOC", "aerAttBetaFR", "aerAttBetaOC", "aerAttBetaNR", "WVMR_RH", "volDepol", "quasiV1", "quasiV2", "TC", "TCV2", "cloudinfo"]
+    "prodSaveList": ["overlap", "aerProfFR", "aerProfNR", "aerProfOC", "aerAttBetaFR", "aerAttBetaOC", "aerAttBetaNR", "WVMR_RH", "volDepol", "quasiV1", "quasiV2", "TC", "TCV2", "cloudinfo", "poliphon_one"]
 }

--- a/lib/interface/picassoProcHistoryData.m
+++ b/lib/interface/picassoProcHistoryData.m
@@ -62,8 +62,11 @@ if endTime < startTime
     error('end time must be larger than start time.');
 end
 
-%% Decompress polly data
-decompressPollyData(startTime, endTime, saveFolder, PicassoConfigFile, varargin{:});
+% %% Decompress polly data
+% decompressPollyData(startTime, endTime, saveFolder, PicassoConfigFile, varargin{:});
+
+%% Look for polly data
+lookforPollyData24h(startTime, endTime, saveFolder, PicassoConfigFile, varargin{:});
 
 %% Process polly data
 picassoProcTodolist(PicassoConfigFile);

--- a/lib/interface/picassoProcHistoryData.m
+++ b/lib/interface/picassoProcHistoryData.m
@@ -63,16 +63,15 @@ if endTime < startTime
     error('end time must be larger than start time.');
 end
 
-% %% Decompress polly data
-% decompressPollyData(startTime, endTime, saveFolder, PicassoConfigFile, varargin{:});
+
 
 if p.Results.flag24hdata
     %% Look for polly data
     lookforPollyData24h(startTime, endTime, saveFolder, PicassoConfigFile, varargin{:});
-
 else
+   %% Decompress polly data
+    decompressPollyData(startTime, endTime, saveFolder, PicassoConfigFile, varargin{:}); 
+end
     %% Process polly data
     picassoProcTodolist(PicassoConfigFile);
-end
-
 end

--- a/lib/interface/picassoProcHistoryData.m
+++ b/lib/interface/picassoProcHistoryData.m
@@ -12,7 +12,7 @@ function picassoProcHistoryData(startTime, endTime, saveFolder, varargin)
 %    saveFolder: char
 %        polly data folder. 
 %        e.g., /oceanethome/pollyxt
-%
+%     flag24data: if 24h nc data is existent (=true) or if data needs to be unzipped 
 % KEYWORDS:
 %    pollyType: char
 %        polly instrument. 
@@ -36,6 +36,7 @@ addRequired(p, 'endTime', @ischar);
 addRequired(p, 'saveFolder', @ischar);
 addParameter(p, 'pollyType', '', @ischar);
 addParameter(p, 'PicassoConfigFile', '', @ischar);
+addParameter(p, 'flag24hdata', false, @islogical);
 
 parse(p, startTime, endTime, saveFolder, varargin{:});
 
@@ -65,10 +66,13 @@ end
 % %% Decompress polly data
 % decompressPollyData(startTime, endTime, saveFolder, PicassoConfigFile, varargin{:});
 
-%% Look for polly data
-lookforPollyData24h(startTime, endTime, saveFolder, PicassoConfigFile, varargin{:});
+if p.Results.flag24hdata
+    %% Look for polly data
+    lookforPollyData24h(startTime, endTime, saveFolder, PicassoConfigFile, varargin{:});
 
-%% Process polly data
-picassoProcTodolist(PicassoConfigFile);
+else
+    %% Process polly data
+    picassoProcTodolist(PicassoConfigFile);
+end
 
 end

--- a/lib/io/lookforPollyData24h.m
+++ b/lib/io/lookforPollyData24h.m
@@ -1,0 +1,121 @@
+function lookforPollyData24h(startDate, endDate, saveFolder, PicassoConfigFile, varargin)
+% DECOMPRESSPOLLYDATA Unzip the polly data and write data info to the todolist file for pollynet processing chain.
+%
+% USAGE:
+%    decompressPollyData(startDate, endDate, saveFolder, PicassoConfigFile)
+%
+% INPUTS:
+%    startDate: numeric
+%        start date of polly data to be decompressed. i.e, datenum(2015, 1, 1) stands for Jan 1st, 2015.
+%    endDate: numeric
+%        stop date of polly data to be decompressed.
+%    saveFolder: char
+%        polly data folder. 
+%        e.g., /oceanethome/pollyxt
+%    PicassoConfigFile: char
+%        the absolute path of the pollynet configuration file.
+%        e.g., /home/picasso/Pollynet_Processing_Chain/config/pollynet_processing_chain_config.json
+%
+% KEYWORDS:
+%    pollyType: char
+%        polly instrument. e.g., arielle
+%    mode: char
+%        If mode was 'a', the polly data info will be appended. If 'w', a new todofile will be created.
+%
+% HISTORY:
+%    - 2019-07-21: First Edition by Zhenping
+%    - 2019-10-16: Add warnings when no polly data files were found.
+%
+% .. Authors: - zhenping@tropos.de
+
+p = inputParser;
+p.KeepUnmatched = true;
+
+addRequired(p, 'startDate', @isnumeric);
+addRequired(p, 'endDate', @isnumeric);
+addRequired(p, 'saveFolder', @ischar);
+addRequired(p, 'PicassoConfigFile', @ischar);
+addParameter(p, 'pollyType', '', @ischar);
+addParameter(p, 'mode', 'a', @ischar);
+
+parse(p, startDate, endDate, saveFolder, PicassoConfigFile, varargin{:});
+
+if isempty(p.Results.pollyType)
+    pollyType = basename(p.Results.saveFolder);
+else
+    pollyType = p.Results.pollyType;
+end
+
+writeMode = p.Results.mode;
+
+% load pollynet_processing_chain config
+if exist(PicassoConfigFile, 'file') ~= 2
+    error(['Error in pollynet_processing_main: ' ...
+           'Unrecognizable configuration file\n%s\n'], PicassoConfigFile);
+else
+    config = loadjson(PicassoConfigFile);
+end
+
+fileCounter = 0;
+for iDate = startDate:ceil(endDate)
+
+    [thisYear, thisMonth, thisDay] = datevec(iDate);
+
+    %% search Polly files
+    files = listfile(fullfile(saveFolder, 'data_zip', sprintf('%04d%02d', thisYear, thisMonth)), ...
+            sprintf('%04d_%02d_%02d.*\\w{2}_\\w{2}_\\w{2}.nc', thisYear, thisMonth, thisDay));
+
+    if isempty(files)
+        fprintf('No polly data for %s at %s\n', pollyType, datestr(iDate, 'yyyy-mm-dd'));
+    end
+
+    fileCounter = fileCounter + length(files);
+
+    for iFile = 1:length(files)
+
+        fileTime = pollyParseFiletime(files{iFile}, '(?<year>\d{4})_(?<month>\d{2})_(?<day>\d{2})_\w*_(?<hour>\d{2})_(?<minute>\d{2})_(?<second>\d{2})\w*.nc');
+
+        if (fileTime > endDate) || (fileTime < startDate)
+            continue;
+        end
+
+        % if there are multiple files in a day, all files will be appended. 
+        if (iFile > 1) && (writeMode == 'w')
+            writeMode = 'a';
+        end
+
+        pollyZipFolder = fileparts(files{iFile});
+        pollyZipFile = basename(files{iFile});
+%        logbookZipFilepath = fullfile(pollyZipFolder, ...
+%                [pollyZipFile(1:(strfind(pollyZipFile, '.zip') - 1)), ...
+%                '.laserlogbook.txt.zip']);
+        todolistFolder = fileparts(config.fileinfo_new);
+       
+        %% write the file to fileinfo_new.txt
+        fid = fopen(config.fileinfo_new, writeMode);
+
+        fileInfo = dir(files{1});
+
+        fprintf(fid, '%s, %s, %s, %s, %d, %s\n', saveFolder, ...
+                fullfile('data_zip'), fullfile([pollyZipFile(1:4), pollyZipFile(6:7)], pollyZipFile), ...
+                fullfile([pollyZipFile(1:4), pollyZipFile(6:7)], pollyZipFile), ...
+                fileInfo.bytes, upper(pollyType));
+
+        fclose(fid);
+    end
+end
+
+if fileCounter == 0
+    warning('No polly data file was found.');
+else
+    fprintf('%d polly data files was found.\n', fileCounter);
+end
+
+%% convert polly housekeeping temp file to laserlogbook file
+% This part is only necessary to be configured when you run this code on the rsd server
+% pollyList = {'pollyxt_tjk', 'pollyxt_cyp'};   % polly list of which needs to be converted
+% pollyTempFolder = {'/data/level0/polly/pollyxt_tjk/log', ...
+%                    '/data/level0/polly/pollyxt_cyp/temps'};   % root directory of the temps file
+% convert_temp_2_laserlogbook(config.fileinfo_new, pollyList, pollyTempFolder);
+
+end

--- a/lib/visualization/pollyxt_displayLTLCali.m
+++ b/lib/visualization/pollyxt_displayLTLCali.m
@@ -120,6 +120,16 @@ if ~ isfield(PollyConfig, 'logbookFile')
     % if 'logbookFile' was no set
     PollyConfig.logbookFile = '';
 end
+
+if isfield(PollyConfig, 'logbookPath')
+    [USER, HOME, OS] = getsysinfo();
+    if strcmp(OS,"win")
+        PollyConfig.logbookFile = fullfile('K:\\',PollyConfig.logbookPath, PollyConfig.logbookFileName)
+    else
+        PollyConfig.logbookFile = fullfile(PollyConfig.logbookPath, PollyConfig.logbookFileName)   
+    end
+ end
+
 logbookInfo = readLogBook(PollyConfig.logbookFile, numel(PollyConfig.first_range_gate_indx));
 flagLogbookTillNow = (logbookInfo.datetime <= PollyDataInfo.dataTime);
 logbookTime = logbookInfo.datetime(flagLogbookTillNow);


### PR DESCRIPTION
With this push a more thorough win compatibility is implemented.

E.g. the log book file is not specified as absolute path in the single configs anymore, but as path and filename independently.

Please check carefully. All changes should be compatible to previous work.

With this push, all platform dependencies shall be able to be addressed in the Processing chain config, so that the same specific polly configs can be used in case one uses different platforms for processing..

Main feature is, that merged netcdf files in 24 h mode can be directly processed now from matlab.