### PR TITLE
Processing corrections2

### DIFF
--- a/lib/interface/picassoProcV3.m
+++ b/lib/interface/picassoProcV3.m
@@ -3528,6 +3528,11 @@ data.quality_mask_WVMR = 3 * ones(size(data.signal, 2), size(data.signal, 3));
 data.quality_mask_RH = 3 * ones(size(data.signal, 2), size(data.signal, 3));
 ones_WV=  ones(size(data.signal, 2), size(data.signal, 3));
 
+TimeM=floor(data.mTime(1)*24/3)*3/24-3/24:3/24:ceil(data.mTime(end)*24/3)*3/24+3/24; %timegrid to search gdas files (3h step)
+
+[TimeMg, HeightMg] = meshgrid(data.height, TimeM); %mehsgrids for 2d interpolation
+[mTimeg, Heightg] = meshgrid(data.height, data.mTime);
+
 if (sum(flag387FR) == 1) && (sum(flag407 == 1))
 
     sig387 = squeeze(data.signal(flag387FR, :, :));
@@ -3556,7 +3561,7 @@ if (sum(flag387FR) == 1) && (sum(flag407 == 1))
 
     % read the meteorological data
     [temp, pres, ~, ~] = loadMeteor(...
-                            mean(data.mTime), data.alt, ...
+                            TimeM, data.alt, ...
                             'meteorDataSource', PollyConfig.meteorDataSource, ...
                             'gdas1Site', PollyConfig.gdas1Site, ...
                             'meteo_folder', PollyConfig.meteo_folder, ...
@@ -3565,19 +3570,19 @@ if (sum(flag387FR) == 1) && (sum(flag407 == 1))
                             'radiosondeType', PollyConfig.radiosondeType);
 
     % repmat the array to matrix as the size of data.signal
-    temperature = repmat(transpose(temp), 1, length(data.mTime));
-    pressure = repmat(transpose(pres), 1, length(data.mTime));
+    temperature = transpose(interp2(TimeMg, HeightMg, temp, mTimeg, Heightg, 'linear'));
+    pressure = transpose(interp2(TimeMg, HeightMg, pres, mTimeg, Heightg, 'linear'));
     % calculate the molecule optical properties
-    [~, mExt387_highres] = rayleigh_scattering(387, transpose(pressure(:, 1)), transpose(temperature(:, 1)) + 273.17, 380, 70);
-    [~, mExt407_highres] = rayleigh_scattering(407, transpose(pressure(:, 1)), transpose(temperature(:, 1)) + 273.17, 380, 70);
+    [~, mExt387_highres] = rayleigh_scattering(387, pres, temp + 273.17, 380, 70);
+    [~, mExt407_highres] = rayleigh_scattering(407, pres, temp + 273.17, 380, 70);
     trans387 = exp(- cumsum(mExt387_highres .* [data.distance0(1), diff(data.distance0)]));
     trans407 = exp(- cumsum(mExt407_highres .* [data.distance0(1), diff(data.distance0)]));
-    TRANS387 = repmat(transpose(trans387), 1, length(data.mTime));
-    TRANS407 = repmat(transpose(trans407), 1, length(data.mTime));
+    TRANS387 = transpose(interp2(TimeMg, HeightMg, trans387, mTimeg, Heightg, 'linear'));
+    TRANS407 = transpose(interp2(TimeMg, HeightMg, trans407, mTimeg, Heightg, 'linear'));
 
     % calculate the saturation water vapor pressure
-    es = saturated_vapor_pres(temperature(:, 1));
-    ES = repmat(es, 1, length(data.mTime));
+    ES = saturated_vapor_pres(temperature);
+
 
     % rhoAir = rho_air(pressure(:, 1), temperature(:, 1) + 273.17);
     % RHOAIR = repmat(rhoAir, 1, length(data.mTime));
@@ -4170,75 +4175,75 @@ print_msg('Finish\n', 'flagTimestamp', true);
 %% attenuated backscatter
 print_msg('Start calculating attenuated backscatter.\n', 'flagTimestamp', true);
 
-data.att_beta_355 = NaN(length(data.height), length(data.mTime));
+data.att_beta_355 = NaN(length(data.distance0), length(data.mTime));
 if (sum(flag355t) == 1)
-    data.att_beta_355 = squeeze(data.signal(flag355t, :, :)) .* repmat(transpose(data.height), 1, length(data.mTime)).^2 / data.LCUsed.LCUsed355;
+    data.att_beta_355 = squeeze(data.signal(flag355t, :, :)) .* repmat(transpose(data.distance0), 1, length(data.mTime)).^2 / data.LCUsed.LCUsed355;
     data.att_beta_355(:, data.depCalMask) = NaN;
 end
 
-data.att_beta_532 = NaN(length(data.height), length(data.mTime));
+data.att_beta_532 = NaN(length(data.distance0), length(data.mTime));
 if (sum(flag532t) == 1)
-    data.att_beta_532 = squeeze(data.signal(flag532t, :, :)) .* repmat(transpose(data.height), 1, length(data.mTime)).^2 / data.LCUsed.LCUsed532;
+    data.att_beta_532 = squeeze(data.signal(flag532t, :, :)) .* repmat(transpose(data.distance0), 1, length(data.mTime)).^2 / data.LCUsed.LCUsed532;
     data.att_beta_532(:, data.depCalMask) = NaN;
 end
 
-data.att_beta_1064 = NaN(length(data.height), length(data.mTime));
+data.att_beta_1064 = NaN(length(data.distance0), length(data.mTime));
 if (sum(flag1064t) == 1)
-    data.att_beta_1064 = squeeze(data.signal(flag1064t, :, :)) .* repmat(transpose(data.height), 1, length(data.mTime)).^2 / data.LCUsed.LCUsed1064;
+    data.att_beta_1064 = squeeze(data.signal(flag1064t, :, :)) .* repmat(transpose(data.distance0), 1, length(data.mTime)).^2 / data.LCUsed.LCUsed1064;
     data.att_beta_1064(:, data.depCalMask) = NaN;
 end
 
-att_beta_387 = NaN(length(data.height), length(data.mTime));
+att_beta_387 = NaN(length(data.distance0), length(data.mTime));
 if (sum(flag387FR) == 1)
-    att_beta_387 = squeeze(data.signal(flag387FR, :, :)) .* repmat(transpose(data.height), 1, length(data.mTime)).^2 / data.LCUsed.LCUsed387;
+    att_beta_387 = squeeze(data.signal(flag387FR, :, :)) .* repmat(transpose(data.distance0), 1, length(data.mTime)).^2 / data.LCUsed.LCUsed387;
     att_beta_387(:, data.depCalMask) = NaN;
 end
 
-att_beta_607 = NaN(length(data.height), length(data.mTime));
+att_beta_607 = NaN(length(data.distance0), length(data.mTime));
 if (sum(flag607FR) == 1)
-    att_beta_607 = squeeze(data.signal(flag607FR, :, :)) .* repmat(transpose(data.height), 1, length(data.mTime)).^2 / data.LCUsed.LCUsed607;
+    att_beta_607 = squeeze(data.signal(flag607FR, :, :)) .* repmat(transpose(data.distance0), 1, length(data.mTime)).^2 / data.LCUsed.LCUsed607;
     att_beta_607(:, data.depCalMask) = NaN;
 end
 
-data.att_beta_OC_355 = NaN(length(data.height), length(data.mTime));
+data.att_beta_OC_355 = NaN(length(data.distance0), length(data.mTime));
 if (sum(flag355t) == 1)
-    data.att_beta_OC_355 = data.sigOLCor355 .* repmat(transpose(data.height), 1, length(data.mTime)).^2 / data.LCUsed.LCUsed355;
+    data.att_beta_OC_355 = data.sigOLCor355 .* repmat(transpose(data.distance0), 1, length(data.mTime)).^2 / data.LCUsed.LCUsed355;
     data.att_beta_OC_355(:, data.depCalMask) = NaN;
 end
 
-data.att_beta_OC_532 = NaN(length(data.height), length(data.mTime));
+data.att_beta_OC_532 = NaN(length(data.distance0), length(data.mTime));
 if (sum(flag532t) == 1)
-    data.att_beta_OC_532 = data.sigOLCor532 .* repmat(transpose(data.height), 1, length(data.mTime)).^2 / data.LCUsed.LCUsed532;
+    data.att_beta_OC_532 = data.sigOLCor532 .* repmat(transpose(data.distance0), 1, length(data.mTime)).^2 / data.LCUsed.LCUsed532;
     data.att_beta_OC_532(:, data.depCalMask) = NaN;
 end
 
-data.att_beta_OC_1064 = NaN(length(data.height), length(data.mTime));
+data.att_beta_OC_1064 = NaN(length(data.distance0), length(data.mTime));
 if (sum(flag1064t) == 1)
-    data.att_beta_OC_1064 = data.sigOLCor1064 .* repmat(transpose(data.height), 1, length(data.mTime)).^2 / data.LCUsed.LCUsed1064;
+    data.att_beta_OC_1064 = data.sigOLCor1064 .* repmat(transpose(data.distance0), 1, length(data.mTime)).^2 / data.LCUsed.LCUsed1064;
     data.att_beta_OC_1064(:, data.depCalMask) = NaN;
 end
 
-% att_beta_OC_387 = NaN(length(data.height), length(data.mTime));
+% att_beta_OC_387 = NaN(length(data.distance0), length(data.mTime));
 % if (sum(flag387FR) == 1)
-%     att_beta_OC_387 = sigOLCor387 .* repmat(transpose(data.height), 1, length(data.mTime)).^2 / data.LCUsed.LCUsed387;
+%     att_beta_OC_387 = sigOLCor387 .* repmat(transpose(data.distance0), 1, length(data.mTime)).^2 / data.LCUsed.LCUsed387;
 %     att_beta_OC_387(:, data.depCalMask) = NaN;
 % end
 
-% att_beta_OC_607 = NaN(length(data.height), length(data.mTime));
+% att_beta_OC_607 = NaN(length(data.distance0), length(data.mTime));
 % if (sum(flag607FR) == 1)
-%     att_beta_OC_607 = sigOLCor607 .* repmat(transpose(data.height), 1, length(data.mTime)).^2 / data.LCUsed.LCUsed607;
+%     att_beta_OC_607 = sigOLCor607 .* repmat(transpose(data.distance0), 1, length(data.mTime)).^2 / data.LCUsed.LCUsed607;
 %     att_beta_OC_607(:, data.depCalMask) = NaN;
 % end
 
-data.att_beta_NR_355 = NaN(length(data.height), length(data.mTime));
+data.att_beta_NR_355 = NaN(length(data.distance0), length(data.mTime));
 if (sum(flag355NR) == 1)
-    data.att_beta_NR_355 = squeeze(data.signal(flag355NR, :, :)) .* repmat(transpose(data.height), 1, length(data.mTime)).^2 / data.LCUsed.LCUsed355NR;
+    data.att_beta_NR_355 = squeeze(data.signal(flag355NR, :, :)) .* repmat(transpose(data.distance0), 1, length(data.mTime)).^2 / data.LCUsed.LCUsed355NR;
     data.att_beta_NR_355(:, data.depCalMask) = NaN;
 end
 
-data.att_beta_NR_532 = NaN(length(data.height), length(data.mTime));
+data.att_beta_NR_532 = NaN(length(data.distance0), length(data.mTime));
 if (sum(flag532NR) == 1)
-    data.att_beta_NR_532 = squeeze(data.signal(flag532NR, :, :)) .* repmat(transpose(data.height), 1, length(data.mTime)).^2 / data.LCUsed.LCUsed532NR;
+    data.att_beta_NR_532 = squeeze(data.signal(flag532NR, :, :)) .* repmat(transpose(data.distance0), 1, length(data.mTime)).^2 / data.LCUsed.LCUsed532NR;
     data.att_beta_NR_532(:, data.depCalMask) = NaN;
 end
 
@@ -4315,7 +4320,7 @@ print_msg('Finish.\n', 'flagTimestamp', true);
 print_msg('Start quasi-retrieval (V1).\n', 'flagTimestamp', true);
 
 % load meteorological data
-[temperature, pressure, ~, ~, ~, thisMeteorAttri] = loadMeteor(mean(data.mTime), data.alt, ...
+[temperature, pressure, ~, ~, ~, thisMeteorAttri] = loadMeteor(TimeM, data.alt, ...
     'meteorDataSource', PollyConfig.meteorDataSource, ...
     'gdas1Site', PollyConfig.gdas1Site, ...
     'meteo_folder', PollyConfig.meteo_folder, ...
@@ -4341,8 +4346,8 @@ if (sum(flag355t) == 1)
     % Rayleigh scattering
 %---------------achtung
     [mBsc355, mExt355] = rayleigh_scattering(355, pressure, temperature + 273.17, 380, 70);
-    mBsc355 = repmat(transpose(mBsc355), 1, length(data.mTime));
-    mExt355 = repmat(transpose(mExt355), 1, length(data.mTime));
+    mBsc355 = transpose(interp2(TimeMg, HeightMg, mBsc355, mTimeg, Heightg, 'linear'));
+    mExt355 = transpose(interp2(TimeMg, HeightMg, mExt355, mTimeg, Heightg, 'linear'));
     data.quasiAttri.flagGDAS1 = strcmpi(thisMeteorAttri.dataSource, 'gdas1');
     data.quasiAttri.meteorSource = thisMeteorAttri.dataSource;
     data.quasiAttri.timestamp = thisMeteorAttri.datetime;
@@ -4367,8 +4372,8 @@ if (sum(flag532t) == 1)
     % Rayleigh scattering
     [mBsc532, mExt532] = rayleigh_scattering(532, pressure, temperature + 273.17, 380, 70);
   %achtung
-    mBsc532 = repmat(transpose(mBsc532), 1, length(data.mTime));
-    mExt532 = repmat(transpose(mExt532), 1, length(data.mTime));
+    mBsc532 = transpose(interp2(TimeMg, HeightMg, mBsc532, mTimeg, Heightg, 'linear'));
+    mExt532 = transpose(interp2(TimeMg, HeightMg, mExt532, mTimeg, Heightg, 'linear'));
     data.quasiAttri.flagGDAS1 = strcmpi(thisMeteorAttri.dataSource, 'gdas1');
     data.quasiAttri.meteorSource = thisMeteorAttri.dataSource;
     data.quasiAttri.timestamp = thisMeteorAttri.datetime;
@@ -4393,8 +4398,8 @@ if (sum(flag1064t) == 1)
     % Rayleigh scattering
 %achtung
     [mBsc1064, mExt1064] = rayleigh_scattering(1064, pressure, temperature + 273.17, 380, 70);
-    mBsc1064 = repmat(transpose(mBsc1064), 1, length(data.mTime));
-    mExt1064 = repmat(transpose(mExt1064), 1, length(data.mTime));
+    mBsc1064 = transpose(interp2(TimeMg, HeightMg, mBsc1064, mTimeg, Heightg, 'linear'));
+    mExt1064 = transpose(interp2(TimeMg, HeightMg, mExt1064, mTimeg, Heightg, 'linear'));
     data.quasiAttri.flagGDAS1 = strcmpi(thisMeteorAttri.dataSource, 'gdas1');
     data.quasiAttri.meteorSource = thisMeteorAttri.dataSource;
     data.quasiAttri.timestamp = thisMeteorAttri.datetime;
@@ -4422,7 +4427,7 @@ if flagGHK
 
         % Rayleigh scattering
         [mBsc532, ~] = rayleigh_scattering(532, pressure, temperature + 273.17, 380, 70);
-        mBsc532 = repmat(transpose(mBsc532), 1, length(data.mTime));
+        mBsc532 = transpose(interp2(TimeMg, HeightMg, mBsc532, mTimeg, Heightg, 'linear'));
         data.quasiAttri.flagGDAS1 = strcmpi(thisMeteorAttri.dataSource, 'gdas1');
         data.quasiAttri.meteorSource = thisMeteorAttri.dataSource;
         data.quasiAttri.timestamp = thisMeteorAttri.datetime;
@@ -4446,7 +4451,7 @@ else
 
         % Rayleigh scattering
         [mBsc532, ~] = rayleigh_scattering(532, pressure, temperature + 273.17, 380, 70);
-        mBsc532 = repmat(transpose(mBsc532), 1, length(data.mTime));
+        mBsc532 = transpose(interp2(TimeMg, HeightMg, mBsc532, mTimeg, Heightg, 'linear'));
         data.quasiAttri.flagGDAS1 = strcmpi(thisMeteorAttri.dataSource, 'gdas1');
         data.quasiAttri.meteorSource = thisMeteorAttri.dataSource;
         data.quasiAttri.timestamp = thisMeteorAttri.datetime;
@@ -4529,9 +4534,9 @@ if (sum(flag355t) == 1) && (sum(flag387FR) == 1)
     % Rayleigh scattering
     [mBsc355, mExt355] = rayleigh_scattering(355, pressure, temperature + 273.17, 380, 70);
     [~, mExt387] = rayleigh_scattering(387, pressure, temperature + 273.17, 380, 70);
-    mBsc355 = repmat(transpose(mBsc355), 1, length(data.mTime));
-    mExt355 = repmat(transpose(mExt355), 1, length(data.mTime));
-    mExt387 = repmat(transpose(mExt387), 1, length(data.mTime));
+    mBsc355 = transpose(interp2(TimeMg, HeightMg, mBsc355, mTimeg, Heightg, 'linear'));
+    mExt355 = transpose(interp2(TimeMg, HeightMg, mExt355, mTimeg, Heightg, 'linear'));
+    mExt387 = transpose(interp2(TimeMg, HeightMg, mExt387, mTimeg, Heightg, 'linear'));
     data.quasiAttri.flagGDAS1 = strcmpi(thisMeteorAttri.dataSource, 'gdas1');
     data.quasiAttri.meteorSource = thisMeteorAttri.dataSource;
     data.quasiAttri.timestamp = thisMeteorAttri.datetime;
@@ -4553,9 +4558,9 @@ if (sum(flag532t) == 1) && (sum(flag607FR) == 1)
     % Rayleigh scattering
     [mBsc532, mExt532] = rayleigh_scattering(532, pressure, temperature + 273.17, 380, 70);
     [~, mExt607] = rayleigh_scattering(607, pressure, temperature + 273.17, 380, 70);
-    mBsc532 = repmat(transpose(mBsc532), 1, length(data.mTime));
-    mExt532 = repmat(transpose(mExt532), 1, length(data.mTime));
-    mExt607 = repmat(transpose(mExt607), 1, length(data.mTime));
+    mBsc532 = transpose(interp2(TimeMg, HeightMg, mBsc532, mTimeg, Heightg, 'linear'));
+    mExt532 = transpose(interp2(TimeMg, HeightMg, mExt532, mTimeg, Heightg, 'linear'));
+    mExt607 = transpose(interp2(TimeMg, HeightMg, mExt607, mTimeg, Heightg, 'linear'));
     data.quasiAttri.flagGDAS1 = strcmpi(thisMeteorAttri.dataSource, 'gdas1');
     data.quasiAttri.meteorSource = thisMeteorAttri.dataSource;
     data.quasiAttri.timestamp = thisMeteorAttri.datetime;
@@ -4577,9 +4582,9 @@ if (sum(flag1064t) == 1) && (sum(flag607FR) == 1)
     % Rayleigh scattering
     [mBsc1064, mExt1064] = rayleigh_scattering(1064, pressure, temperature + 273.17, 380, 70);
     [~, mExt607] = rayleigh_scattering(607, pressure, temperature + 273.17, 380, 70);
-    mBsc1064 = repmat(transpose(mBsc1064), 1, length(data.mTime));
-    mExt1064 = repmat(transpose(mExt1064), 1, length(data.mTime));
-    mExt607 = repmat(transpose(mExt607), 1, length(data.mTime));
+    mBsc1064 = transpose(interp2(TimeMg, HeightMg, mBsc1064, mTimeg, Heightg, 'linear'));
+    mExt1064 = transpose(interp2(TimeMg, HeightMg, mExt1064, mTimeg, Heightg, 'linear'));
+    mExt607 = transpose(interp2(TimeMg, HeightMg, mExt607, mTimeg, Heightg, 'linear'));
     data.quasiAttri.flagGDAS1 = strcmpi(thisMeteorAttri.dataSource, 'gdas1');
     data.quasiAttri.meteorSource = thisMeteorAttri.dataSource;
     data.quasiAttri.timestamp = thisMeteorAttri.datetime;
@@ -4602,7 +4607,7 @@ if flagGHK
 
         % Rayleigh scattering
         [mBsc532, ~] = rayleigh_scattering(532, pressure, temperature + 273.17, 380, 70);
-        mBsc532 = repmat(transpose(mBsc532), 1, length(data.mTime));
+        mBsc532 = transpose(interp2(TimeMg, HeightMg, mBsc532, mTimeg, Heightg, 'linear'));    
         data.quasiAttri.flagGDAS1 = strcmpi(thisMeteorAttri.dataSource, 'gdas1');
         data.quasiAttri.meteorSource = thisMeteorAttri.dataSource;
         data.quasiAttri.timestamp = thisMeteorAttri.datetime;
@@ -4626,7 +4631,7 @@ else
 
         % Rayleigh scattering
         [mBsc532, ~] = rayleigh_scattering(532, pressure, temperature + 273.17, 380, 70);
-        mBsc532 = repmat(transpose(mBsc532), 1, length(data.mTime));
+        mBsc532 = transpose(interp2(TimeMg, HeightMg, mBsc532, mTimeg, Heightg, 'linear'));    
         data.quasiAttri.flagGDAS1 = strcmpi(thisMeteorAttri.dataSource, 'gdas1');
         data.quasiAttri.meteorSource = thisMeteorAttri.dataSource;
         data.quasiAttri.timestamp = thisMeteorAttri.datetime;

--- a/lib/io/loadMeteor.m
+++ b/lib/io/loadMeteor.m
@@ -54,6 +54,8 @@ function [temp, pres, relh, wins, wind, meteorAttri] = loadMeteor(mTime, asl, va
 %
 % HISTORY:
 %    - 2021-05-22: first edition by Zhenping
+%    - 2025-02-19: modified by C. Jimenez (smoothing added into meteo
+%    profiles)
 %
 % .. Authors: - zhenping@tropos.de
 
@@ -72,6 +74,8 @@ addParameter(p, 'flagTemporalInterp', false, @islogical);
 addParameter(p, 'flagReadLess', false, @islogical);
 addParameter(p, 'method', 'nearest', @ischar);
 addParameter(p, 'isUseLatestGDAS', true, @islogical);
+addParameter(p, 'SmoothMeteo', 7, @isnumeric);
+
 
 parse(p, mTime, asl, varargin{:});
 meteorAttri.dataSource = cell(0);
@@ -114,11 +118,11 @@ for iTime = 1:length(mTimeQry)
     meteorAttri.datetime = cat(2, meteorAttri.datetime, attri.datetime);
 
     % interp the parameters
-    tempI = interpMeteor(altRaw, tempRaw, asl);
-    presI = interpMeteor(altRaw, presRaw, asl);
-    relhI = interpMeteor(altRaw, relhRaw, asl);
-    winsI = interpMeteor(altRaw, winsRaw, asl);
-    windI = interpMeteor(altRaw, windRaw, asl);
+    tempI = transpose(smooth(interpMeteor(altRaw, tempRaw, asl),p.Results.SmoothMeteo,'moving'));
+    presI = transpose(smooth(interpMeteor(altRaw, presRaw, asl),p.Results.SmoothMeteo,'moving'));
+    relhI = transpose(smooth(interpMeteor(altRaw, relhRaw, asl),p.Results.SmoothMeteo,'moving'));
+    winsI = transpose(smooth(interpMeteor(altRaw, winsRaw, asl),p.Results.SmoothMeteo,'moving'));
+    windI = transpose(smooth(interpMeteor(altRaw, windRaw, asl),p.Results.SmoothMeteo,'moving'));
 
     % concatenate the parameters
     tempQry = cat(1, tempQry, tempI);


### PR DESCRIPTION
The following corrections were made (now in the dev branch):

Using the median shot number to recalculate the signal in photon counts, ensuring that it is not dependent on the number of shots in each time bin.
A small smoothing is added to the meteorological data to avoid sharp changes in the slope of the temperature.
Read all gdas files during the period and interpolate the molecular optical properties to the 30s grid to improve the accuracy of the molecular representation when performing high-resolution retrievals (WV and quasi retrievals).
The last two commits are only to undo some unnoticed and undesired changes.