### PR TITLE
Calculation of co and cross component of the attenuated backscatter

### DIFF
--- a/lib/interface/picassoProcV3.m
+++ b/lib/interface/picassoProcV3.m
@@ -50,9 +50,14 @@ function [report] = picassoProcV3(pollyDataFile, pollyType, PicassoConfigFile, v
 %        processing report.
 %
 % HISTORY:
-%    - 2021-06-25: first edition by Zhenping
+%    - 2021-06-25: first edition by Zhenping Yin
+%    - 2023-06-06: Overlap function using Raman method was added by Cristofer Jimenez
+%    - 2023-06-14: POLIPHON method (step 1) added by Athena Floutsi
+%    - 2024-08-28: GHK formalism for depol calculation implemented by Moritz Haarig
+%    - 2025-02-19: Smoothing added into meteo profiles, read all meteo data for HR products and interpolate, recalculation of signals using mean shot_number by Cristofer Jimenez 
+%    - 2025-03-14: Compute and save attenuated backscatter co and cross polarized by Cristofer Jimenez
 %
-% .. Authors: - zhenping@tropos.de
+% .. Authors: - zhenping@tropos.de, jimenez@tropos.de, floutsi@tropos.de, haarig@tropos.de
 
 global PicassoConfig
 global CampaignConfig
@@ -4316,6 +4321,27 @@ else
 end
 print_msg('Finish.\n', 'flagTimestamp', true);
 
+%% Co (para) and cross (perp) polarized components in attenuated backscatter
+print_msg('Start calculating co and cross attenuated backscatter.\n', 'flagTimestamp', true);
+
+data.att_beta_para_355 = NaN(length(data.height), length(data.mTime));
+data.att_beta_perp_355 = NaN(length(data.height), length(data.mTime));
+if (sum(flag355t) == 1) && (sum(flag355c) == 1)
+data.att_beta_para_355=data.att_beta_355./(1+PollyConfig.TR(flag355t)*data.vdr355);
+data.att_beta_perp_355=data.att_beta_para_355.*data.vdr355;
+end
+data.att_beta_para_532 = NaN(length(data.height), length(data.mTime));
+data.att_beta_perp_532 = NaN(length(data.height), length(data.mTime));
+if (sum(flag532t) == 1) && (sum(flag532c) == 1)
+data.att_beta_para_532=data.att_beta_532./(1+PollyConfig.TR(flag532t)*data.vdr532);
+data.att_beta_perp_532=data.att_beta_para_532.*data.vdr532;
+end
+data.att_beta_para_1064 = NaN(length(data.height), length(data.mTime));
+data.att_beta_perp_1064 = NaN(length(data.height), length(data.mTime));
+if (sum(flag1064t) == 1) && (sum(flag1064c) == 1)
+data.att_beta_para_1064=data.att_beta_1064./(1+PollyConfig.TR(flag1064t)*data.vdr1064);
+data.att_beta_perp_1064=data.att_beta_para_1064.*data.vdr1064;
+end
 %% Quasi-retrieval (V1)
 print_msg('Start quasi-retrieval (V1).\n', 'flagTimestamp', true);
 

--- a/lib/io/pollySaveAttnBeta.m
+++ b/lib/io/pollySaveAttnBeta.m
@@ -11,8 +11,9 @@ function pollySaveAttnBeta(data)
 %    - 2019-01-10: First Edition by Zhenping
 %    - 2019-05-16: Extended the attributes for all the variables and comply with the ACTRIS convention.
 %    - 2019-09-27: Turn on the netCDF4 compression.
+%    - 2025-03-14: co and cross polarized components were added to the saving list by Cristofer Jimenez
 %
-% .. Authors: - zhenping@tropos.de
+% .. Authors: - zhenping@tropos.de, jimenez@tropos.de
 
 missing_value = -999;
 
@@ -38,8 +39,14 @@ varID_time = netcdf.defVar(ncID, 'time', 'NC_DOUBLE', dimID_time);
 varID_height = netcdf.defVar(ncID, 'height', 'NC_FLOAT', dimID_height);
 varID_tilt_angle = netcdf.defVar(ncID, 'tilt_angle', 'NC_FLOAT', dimID_constant);
 varID_att_bsc_355 = netcdf.defVar(ncID, 'attenuated_backscatter_355nm', 'NC_FLOAT', [dimID_height, dimID_time]);
+varID_att_bsc_para_355 = netcdf.defVar(ncID, 'attenuated_backscatter_para_355nm', 'NC_FLOAT', [dimID_height, dimID_time]);
+varID_att_bsc_perp_355 = netcdf.defVar(ncID, 'attenuated_backscatter_perp_355nm', 'NC_FLOAT', [dimID_height, dimID_time]);
 varID_att_bsc_532 = netcdf.defVar(ncID, 'attenuated_backscatter_532nm', 'NC_FLOAT', [dimID_height, dimID_time]);
+varID_att_bsc_para_532 = netcdf.defVar(ncID, 'attenuated_backscatter_para_532nm', 'NC_FLOAT', [dimID_height, dimID_time]);
+varID_att_bsc_perp_532 = netcdf.defVar(ncID, 'attenuated_backscatter_perp_532nm', 'NC_FLOAT', [dimID_height, dimID_time]);
 varID_att_bsc_1064 = netcdf.defVar(ncID, 'attenuated_backscatter_1064nm', 'NC_FLOAT', [dimID_height, dimID_time]);
+varID_att_bsc_para_1064 = netcdf.defVar(ncID, 'attenuated_backscatter_para_1064nm', 'NC_FLOAT', [dimID_height, dimID_time]);
+varID_att_bsc_perp_1064 = netcdf.defVar(ncID, 'attenuated_backscatter_perp_1064nm', 'NC_FLOAT', [dimID_height, dimID_time]);
 varID_quality_mask_355 = netcdf.defVar(ncID, 'quality_mask_355nm', 'NC_BYTE', [dimID_height, dimID_time]);
 varID_quality_mask_532 = netcdf.defVar(ncID, 'quality_mask_532nm', 'NC_BYTE', [dimID_height, dimID_time]);
 varID_quality_mask_1064 = netcdf.defVar(ncID, 'quality_mask_1064nm', 'NC_BYTE', [dimID_height, dimID_time]);
@@ -51,6 +58,12 @@ varID_SNR_1064 = netcdf.defVar(ncID, 'SNR_1064nm', 'NC_FLOAT', [dimID_height, di
 netcdf.defVarFill(ncID, varID_att_bsc_355, false, missing_value);
 netcdf.defVarFill(ncID, varID_att_bsc_532, false, missing_value);
 netcdf.defVarFill(ncID, varID_att_bsc_1064, false, missing_value);
+netcdf.defVarFill(ncID, varID_att_bsc_para_355, false, missing_value);
+netcdf.defVarFill(ncID, varID_att_bsc_para_532, false, missing_value);
+netcdf.defVarFill(ncID, varID_att_bsc_para_1064, false, missing_value);
+netcdf.defVarFill(ncID, varID_att_bsc_perp_355, false, missing_value);
+netcdf.defVarFill(ncID, varID_att_bsc_perp_532, false, missing_value);
+netcdf.defVarFill(ncID, varID_att_bsc_perp_1064, false, missing_value);
 netcdf.defVarFill(ncID, varID_quality_mask_355, false, 1);
 netcdf.defVarFill(ncID, varID_quality_mask_532, false, 1);
 netcdf.defVarFill(ncID, varID_quality_mask_1064, false, 1);
@@ -62,6 +75,12 @@ netcdf.defVarFill(ncID, varID_SNR_1064, false, missing_value);
 netcdf.defVarDeflate(ncID, varID_att_bsc_355, true, true, 5);
 netcdf.defVarDeflate(ncID, varID_att_bsc_532, true, true, 5);
 netcdf.defVarDeflate(ncID, varID_att_bsc_1064, true, true, 5);
+netcdf.defVarDeflate(ncID, varID_att_bsc_para_355, true, true, 5);
+netcdf.defVarDeflate(ncID, varID_att_bsc_para_532, true, true, 5);
+netcdf.defVarDeflate(ncID, varID_att_bsc_para_1064, true, true, 5);
+netcdf.defVarDeflate(ncID, varID_att_bsc_perp_355, true, true, 5);
+netcdf.defVarDeflate(ncID, varID_att_bsc_perp_532, true, true, 5);
+netcdf.defVarDeflate(ncID, varID_att_bsc_perp_1064, true, true, 5);
 netcdf.defVarDeflate(ncID, varID_quality_mask_355, true, true, 5);
 netcdf.defVarDeflate(ncID, varID_quality_mask_532, true, true, 5);
 netcdf.defVarDeflate(ncID, varID_quality_mask_1064, true, true, 5);
@@ -87,6 +106,12 @@ netcdf.putVar(ncID, varID_tilt_angle, single(data.angle));
 netcdf.putVar(ncID, varID_att_bsc_355, single(fillmissing(data.att_beta_355, missing_value)));
 netcdf.putVar(ncID, varID_att_bsc_532, single(fillmissing(data.att_beta_532, missing_value)));
 netcdf.putVar(ncID, varID_att_bsc_1064, single(fillmissing(data.att_beta_1064, missing_value)));
+netcdf.putVar(ncID, varID_att_bsc_para_355, single(fillmissing(data.att_beta_para_355, missing_value)));
+netcdf.putVar(ncID, varID_att_bsc_para_532, single(fillmissing(data.att_beta_para_532, missing_value)));
+netcdf.putVar(ncID, varID_att_bsc_para_1064, single(fillmissing(data.att_beta_para_1064, missing_value)));
+netcdf.putVar(ncID, varID_att_bsc_perp_355, single(fillmissing(data.att_beta_perp_355, missing_value)));
+netcdf.putVar(ncID, varID_att_bsc_perp_532, single(fillmissing(data.att_beta_perp_532, missing_value)));
+netcdf.putVar(ncID, varID_att_bsc_perp_1064, single(fillmissing(data.att_beta_perp_1064, missing_value)));
 netcdf.putVar(ncID, varID_quality_mask_355, int8(fillmissing(data.quality_mask_355, 1)));
 netcdf.putVar(ncID, varID_quality_mask_532, int8(fillmissing(data.quality_mask_532, 1)));
 netcdf.putVar(ncID, varID_quality_mask_1064, int8(fillmissing(data.quality_mask_1064, 1)));
@@ -184,6 +209,85 @@ netcdf.putAtt(ncID, varID_att_bsc_1064, 'Lidar_calibration_constant_used', data.
 % netcdf.putAtt(ncID, varID_att_bsc_1064, 'error_variable', 'att_beta_1064_error');
 % netcdf.putAtt(ncID, varID_att_bsc_1064, 'bias_variable', 'att_beta_1064_bias');
 netcdf.putAtt(ncID, varID_att_bsc_1064, 'comment', 'This parameter is calculated with taking into account of the effects of lidar constants. Therefore, it reflects the concentration of aerosol and molecule backscatter.');
+
+% att_bsc_para_355
+netcdf.putAtt(ncID, varID_att_bsc_para_355, 'unit', 'sr^-1 m^-1');
+netcdf.putAtt(ncID, varID_att_bsc_para_355, 'unit_html', 'sr<sup>-1</sup> m<sup>-1</sup>');
+netcdf.putAtt(ncID, varID_att_bsc_para_355, 'long_name', 'co polarized attenuated backscatter at 355 nm');
+netcdf.putAtt(ncID, varID_att_bsc_para_355, 'standard_name', 'att_beta_para_355');
+%netcdf.putAtt(ncID, varID_att_bsc_para_355, 'plot_range', PollyConfig.zLim_att_beta_355/1e6);
+%netcdf.putAtt(ncID, varID_att_bsc_para_355, 'plot_scale', 'linear');
+netcdf.putAtt(ncID, varID_att_bsc_para_355, 'source', CampaignConfig.name);
+%netcdf.putAtt(ncID, varID_att_bsc_para_355, 'Lidar_calibration_constant_used', data.LCUsed.LCUsed355);
+% netcdf.putAtt(ncID, varID_att_bsc_para_355, 'error_variable', 'att_beta_355_error');
+% netcdf.putAtt(ncID, varID_att_bsc_para_355, 'bias_variable', 'att_beta_355_bias');
+netcdf.putAtt(ncID, varID_att_bsc_para_355, 'comment', 'This parameter is calculated with taking into account of the effects of lidar constants. Therefore, it reflects the concentration of aerosol and molecule backscatter. It also make uses of the volume depolarization ratio to get the co polarized component');
+
+% att_bsc_para_532
+netcdf.putAtt(ncID, varID_att_bsc_para_532, 'unit', 'sr^-1 m^-1');
+netcdf.putAtt(ncID, varID_att_bsc_para_532, 'unit_html', 'sr<sup>-1</sup> m<sup>-1</sup>');
+netcdf.putAtt(ncID, varID_att_bsc_para_532, 'long_name', 'co polarized attenuated backscatter at 532 nm');
+netcdf.putAtt(ncID, varID_att_bsc_para_532, 'standard_name', 'att_beta_532');
+%netcdf.putAtt(ncID, varID_att_bsc_para_532, 'plot_range', PollyConfig.zLim_att_beta_532/1e6);
+%netcdf.putAtt(ncID, varID_att_bsc_para_532, 'plot_scale', 'linear');
+netcdf.putAtt(ncID, varID_att_bsc_para_532, 'source', CampaignConfig.name);
+%netcdf.putAtt(ncID, varID_att_bsc_para_532, 'Lidar_calibration_constant_used', data.LCUsed.LCUsed532);
+% netcdf.putAtt(ncID, varID_att_bsc_para_532, 'error_variable', 'att_beta_532_error');
+% netcdf.putAtt(ncID, varID_att_bsc_para_532, 'bias_variable', 'att_beta_532_bias');
+netcdf.putAtt(ncID, varID_att_bsc_para_532, 'comment', 'This parameter is calculated with taking into account of the effects of lidar constants. Therefore, it reflects the concentration of aerosol and molecule backscatter. It also make uses of the volume depolarization ratio to get the co polarized component');
+
+% att_bsc_para_1064
+netcdf.putAtt(ncID, varID_att_bsc_para_1064, 'unit', 'sr^-1 m^-1');
+netcdf.putAtt(ncID, varID_att_bsc_para_1064, 'unit_html', 'sr<sup>-1</sup> m<sup>-1</sup>');
+netcdf.putAtt(ncID, varID_att_bsc_para_1064, 'long_name', 'co polarized attenuated backscatter at 1064 nm');
+netcdf.putAtt(ncID, varID_att_bsc_para_1064, 'standard_name', 'att_beta_1064');
+%netcdf.putAtt(ncID, varID_att_bsc_para_1064, 'plot_range', PollyConfig.zLim_att_beta_1064/1e6);
+%netcdf.putAtt(ncID, varID_att_bsc_para_1064, 'plot_scale', 'linear');
+netcdf.putAtt(ncID, varID_att_bsc_para_1064, 'source', CampaignConfig.name);
+%netcdf.putAtt(ncID, varID_att_bsc_para_1064, 'Lidar_calibration_constant_used', data.LCUsed.LCUsed1064);
+% netcdf.putAtt(ncID, varID_att_bsc_para_1064, 'error_variable', 'att_beta_1064_error');
+% netcdf.putAtt(ncID, varID_att_bsc_para_1064, 'bias_variable', 'att_beta_1064_bias');
+netcdf.putAtt(ncID, varID_att_bsc_para_1064, 'comment', 'This parameter is calculated with taking into account of the effects of lidar constants. Therefore, it reflects the concentration of aerosol and molecule backscatter. It also make uses of the volume depolarization ratio to get the cross polarized component');
+
+
+% att_bsc_perp_355
+netcdf.putAtt(ncID, varID_att_bsc_perp_355, 'unit', 'sr^-1 m^-1');
+netcdf.putAtt(ncID, varID_att_bsc_perp_355, 'unit_html', 'sr<sup>-1</sup> m<sup>-1</sup>');
+netcdf.putAtt(ncID, varID_att_bsc_perp_355, 'long_name', 'cross polarized attenuated backscatter at 355 nm');
+netcdf.putAtt(ncID, varID_att_bsc_perp_355, 'standard_name', 'att_beta_perp_355');
+%netcdf.putAtt(ncID, varID_att_bsc_perp_355, 'plot_range', PollyConfig.zLim_att_beta_355/1e6);
+%netcdf.putAtt(ncID, varID_att_bsc_perp_355, 'plot_scale', 'linear');
+netcdf.putAtt(ncID, varID_att_bsc_perp_355, 'source', CampaignConfig.name);
+%netcdf.putAtt(ncID, varID_att_bsc_perp_355, 'Lidar_calibration_constant_used', data.LCUsed.LCUsed355);
+% netcdf.putAtt(ncID, varID_att_bsc_perp_355, 'error_variable', 'att_beta_355_error');
+% netcdf.putAtt(ncID, varID_att_bsc_perp_355, 'bias_variable', 'att_beta_355_bias');
+netcdf.putAtt(ncID, varID_att_bsc_perp_355, 'comment', 'This parameter is calculated with taking into account of the effects of lidar constants. Therefore, it reflects the concentration of aerosol and molecule backscatter. It also make uses of the volume depolarization ratio to get the cross polarized component');
+
+% att_bsc_perp_532
+netcdf.putAtt(ncID, varID_att_bsc_perp_532, 'unit', 'sr^-1 m^-1');
+netcdf.putAtt(ncID, varID_att_bsc_perp_532, 'unit_html', 'sr<sup>-1</sup> m<sup>-1</sup>');
+netcdf.putAtt(ncID, varID_att_bsc_perp_532, 'long_name', 'cross polarized attenuated backscatter at 532 nm');
+netcdf.putAtt(ncID, varID_att_bsc_perp_532, 'standard_name', 'att_beta_532');
+%netcdf.putAtt(ncID, varID_att_bsc_perp_532, 'plot_range', PollyConfig.zLim_att_beta_532/1e6);
+%netcdf.putAtt(ncID, varID_att_bsc_perp_532, 'plot_scale', 'linear');
+netcdf.putAtt(ncID, varID_att_bsc_perp_532, 'source', CampaignConfig.name);
+%netcdf.putAtt(ncID, varID_att_bsc_perp_532, 'Lidar_calibration_constant_used', data.LCUsed.LCUsed532);
+% netcdf.putAtt(ncID, varID_att_bsc_perp_532, 'error_variable', 'att_beta_532_error');
+% netcdf.putAtt(ncID, varID_att_bsc_perp_532, 'bias_variable', 'att_beta_532_bias');
+netcdf.putAtt(ncID, varID_att_bsc_perp_532, 'comment', 'This parameter is calculated with taking into account of the effects of lidar constants. Therefore, it reflects the concentration of aerosol and molecule backscatter. It also make uses of the volume depolarization ratio to get the cross polarized component');
+
+% att_bsc_perp_1064
+netcdf.putAtt(ncID, varID_att_bsc_perp_1064, 'unit', 'sr^-1 m^-1');
+netcdf.putAtt(ncID, varID_att_bsc_perp_1064, 'unit_html', 'sr<sup>-1</sup> m<sup>-1</sup>');
+netcdf.putAtt(ncID, varID_att_bsc_perp_1064, 'long_name', 'cross polarized attenuated backscatter at 1064 nm');
+netcdf.putAtt(ncID, varID_att_bsc_perp_1064, 'standard_name', 'att_beta_1064');
+%netcdf.putAtt(ncID, varID_att_bsc_perp_1064, 'plot_range', PollyConfig.zLim_att_beta_1064/1e6);
+%netcdf.putAtt(ncID, varID_att_bsc_perp_1064, 'plot_scale', 'linear');
+netcdf.putAtt(ncID, varID_att_bsc_perp_1064, 'source', CampaignConfig.name);
+%netcdf.putAtt(ncID, varID_att_bsc_perp_1064, 'Lidar_calibration_constant_used', data.LCUsed.LCUsed1064);
+% netcdf.putAtt(ncID, varID_att_bsc_perp_1064, 'error_variable', 'att_beta_1064_error');
+% netcdf.putAtt(ncID, varID_att_bsc_perp_1064, 'bias_variable', 'att_beta_1064_bias');
+netcdf.putAtt(ncID, varID_att_bsc_perp_1064, 'comment', 'This parameter is calculated with taking into account of the effects of lidar constants. Therefore, it reflects the concentration of aerosol and molecule backscatter.');
 
 % quality_mask_355
 netcdf.putAtt(ncID, varID_quality_mask_355, 'unit', '');


### PR DESCRIPTION
Motivated by a request from Ronny, I computed the co and cross-polarized components of the attenuated backscatter so that the depol is beta_att_perp/beta_att_para. This would help for comparison, e.g., with Ceilometer.

This may also help when one needs a mean depolarization profile on a specific time window, since averaging the depol directly might induce artifacts.

I also added notes in the Heading of PicassoProcV3.m to keep track of the modifications to the PPC during the last two years (at least the ones I am aware of)